### PR TITLE
Make iOS build post-processor callbackOrder configurable

### DIFF
--- a/Assets/Teak/Editor/TeakSettingsEditor.cs
+++ b/Assets/Teak/Editor/TeakSettingsEditor.cs
@@ -39,6 +39,9 @@ public class TeakSettingsEditor : Editor {
 
         GUIContent sdk5BehaviorsContent = new GUIContent("Enable SDK 5 Behaviors [?]",  "When enabled, the Teak SDK will no longer automatically collect the Facebook Access Token from signed-in users.");
         TeakSettings.EnableSDK5Behaviors = EditorGUILayout.Toggle(sdk5BehaviorsContent, TeakSettings.EnableSDK5Behaviors);
+
+        GUIContent iOSCallbackOrderContent = new GUIContent("iOS Post-Processor Order [?]", "The callbackOrder for the iOS build post-processor. Change this to control when Teak's Xcode project modifications run relative to other post-processors. Default is 100.");
+        TeakSettings.iOSBuildPostProcessorCallbackOrder = EditorGUILayout.IntField(iOSCallbackOrderContent, TeakSettings.iOSBuildPostProcessorCallbackOrder);
     }
 }
 

--- a/Assets/Teak/Editor/TeakXcodeProjectMutator.cs
+++ b/Assets/Teak/Editor/TeakXcodeProjectMutator.cs
@@ -17,7 +17,7 @@ using System.Diagnostics;
 #endregion
 
 public class TeakXcodeProjectMutator : IPostprocessBuildWithReport {
-    public int callbackOrder { get { return 100; } }
+    public int callbackOrder { get { return TeakSettings.iOSBuildPostProcessorCallbackOrder; } }
 
     public void OnPostprocessBuild(BuildReport report) {
         if (TeakSettings.JustShutUpIKnowWhatImDoing) { return; }

--- a/Assets/Teak/TeakSettings.cs
+++ b/Assets/Teak/TeakSettings.cs
@@ -114,6 +114,18 @@ public class TeakSettings : ScriptableObject {
 #endif
     }
 
+    public static int iOSBuildPostProcessorCallbackOrder {
+        get { return Instance.miOSBuildPostProcessorCallbackOrder; }
+#if UNITY_EDITOR
+        set {
+            if (value != Instance.miOSBuildPostProcessorCallbackOrder) {
+                Instance.miOSBuildPostProcessorCallbackOrder = value;
+                DirtyEditor();
+            }
+        }
+#endif
+    }
+
 #if UNITY_EDITOR
     [MenuItem("Edit/Teak Settings...")]
     public static void Edit() {
@@ -137,6 +149,8 @@ public class TeakSettings : ScriptableObject {
     private bool mEnableSDK5Behaviors = true;
     [SerializeField]
     private bool mTraceLogging = false;
+    [SerializeField]
+    private int miOSBuildPostProcessorCallbackOrder = 100;
 
     private static TeakSettings mInstance;
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,53 @@ CircleCI on macOS (Xcode 14.3.1). Two workflows:
 - **un-tagged-build:** Builds package, optionally promotes to tagged release.
 - **tagged-build:** Builds, deploys versioned UPM package to `GoCarrot/upm-package-teak`, uploads `.unitypackage` to S3 (`teak-build-artifacts` bucket). `deploy_latest` requires manual approval.
 
+## Documentation & Changelog
+
+Public documentation is built with **Antora** and lives under `docs/`. API docs are generated via doxygen (`yarn docs`).
+
+### Changelog System
+
+The changelog is published to the documentation site. Source of truth is YAML files in `docs/modules/changelog/versions/`. AsciiDoc partials and the main changelog page are **generated** by `doxygen2adoc` (via `yarn docs`) and gitignored — never edit `.adoc` files under `docs/modules/changelog/`.
+
+- **Adding entries:** Edit `docs/modules/changelog/unreleased.yaml`. When a user-facing change is made, add a line under the appropriate category.
+- **Important:** `unreleased.yaml` lives in `docs/modules/changelog/`, NOT in `versions/`. The `versions/` directory is read by `doxygen2adoc` which requires valid semver filenames — `unreleased.yaml` in that directory will break `yarn docs`.
+- **At release time:** Move `unreleased.yaml` into `versions/<version>.yaml` and create a fresh `unreleased.yaml`.
+- **YAML categories:** `new`, `bug`, `enhancement`, `breaking`, `deprecation`, `upgrade_note`, `known_issue`, `android` (native version), `ios` (native version)
+- **Format:** Each category is a list of strings. Use backticks for code references (doubled in YAML: ` `` `).
+
 ## Branching
 
 - `develop` — active development (default PR target)
 - `X.Y-stable` — maintenance branches (e.g. `4.3-stable`)
+
+## Commit Message Format
+
+Every commit must include a full human-Claude interaction log. Placeholders
+below are in angle brackets — replace them with actual content, do not include
+the brackets. The interaction log only covers prompts since the previous commit,
+not the entire session.
+
+```
+Brief description of what was done
+
+Technical description of changes made
+
+## Human-Claude Interaction Log
+
+### Human prompts (VERBATIM - include typos, informal language, COMPLETE text):
+**Include EVERY prompt since last commit - even short ones, corrections, clarifications**
+1. "<copy-paste ENTIRE first prompt since last commit>"
+   → Claude: <what Claude did in response>
+
+2. "<copy-paste ENTIRE second prompt>"
+   → Claude: <how Claude adjusted>
+
+<continue numbering ALL prompts - don't skip any or judge importance>
+
+### Key decisions made:
+- Human guided: <specific guidance provided>
+- Claude discovered: <patterns found>
+
+🤖 Generated with Claude Code
+Co-Authored-By: Claude <noreply@anthropic.com>
+```

--- a/docs/modules/changelog/unreleased.yaml
+++ b/docs/modules/changelog/unreleased.yaml
@@ -1,0 +1,2 @@
+new:
+  - The iOS build post-processor callback order is now configurable in Teak Settings, allowing resolution of ordering conflicts with other post-processors such as Crashlytics.


### PR DESCRIPTION
## Summary
- Add `iOSBuildPostProcessorCallbackOrder` to `TeakSettings` (default `100`), exposed in the Unity inspector under Build Settings
- `TeakXcodeProjectMutator` now reads from this setting instead of returning a hardcoded value
- Customers who hit ordering conflicts with other post-processors (e.g. Crashlytics at `100`) can adjust the value to control execution order

Closes #101

## Changelog & Docs
- Add `docs/modules/changelog/unreleased.yaml` for tracking unreleased changes (lives outside `versions/` to avoid breaking `doxygen2adoc` semver sort)
- Document the changelog system and docs pipeline in `CLAUDE.md`

## Test plan
- [ ] iOS build with Crashlytics installed: verify adjusting the callback order in Teak Settings changes the relative ordering of Xcode build phases
- [ ] Verify default value of `100` preserves existing behavior for customers who don't change the setting
- [ ] Run `yarn docs` to confirm unreleased.yaml location doesn't break doc generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)