### PR TITLE
Add callback form for RegisterForProvisionalNotifications

### DIFF
--- a/Assets/Teak/Teak.cs
+++ b/Assets/Teak/Teak.cs
@@ -682,9 +682,9 @@ public partial class Teak : MonoBehaviour {
     /// <summary>
     /// Register for Provisional Push Notifications.
     /// </summary>
-    /// \deprecated Please use <see cref="RegisterForProvisionalNotifications(System.Action)"/> instead.
+    /// \deprecated Please use <see cref="RegisterForProvisionalNotifications(System.Action{bool})"/> instead.
     /// <remarks>
-    /// This is a compatibility method which simply wraps <see cref="RegisterForProvisionalNotifications(System.Action)"/> in
+    /// This is a compatibility method which simply wraps <see cref="RegisterForProvisionalNotifications(System.Action{bool})"/> in
     /// a StartCoroutine()
     /// </remarks>
     /// <returns>true if the device was an iOS 12+ device</returns>
@@ -754,7 +754,9 @@ public partial class Teak : MonoBehaviour {
         bool keepWaiting = true;
         string callbackId = DateTime.Now.Ticks.ToString();
         teakOperationCallbackMap.Add(callbackId, json => {
-            callback(json.ContainsKey("permissionGranted") && json["permissionGranted"] is bool && (bool)json["permissionGranted"]);
+            if (callback != null) {
+                callback(json.ContainsKey("permissionGranted") && json["permissionGranted"] is bool && (bool)json["permissionGranted"]);
+            }
             keepWaiting = false;
         });
         TeakRequestPushAuthorizationUnity(false, callbackId);

--- a/Assets/Teak/Teak.cs
+++ b/Assets/Teak/Teak.cs
@@ -682,15 +682,47 @@ public partial class Teak : MonoBehaviour {
     /// <summary>
     /// Register for Provisional Push Notifications.
     /// </summary>
+    /// \deprecated Please use <see cref="RegisterForProvisionalNotifications(System.Action)"/> instead.
     /// <remarks>
-    /// This method only has any effect on iOS devices running iOS 12 or higher.
+    /// This is a compatibility method which simply wraps <see cref="RegisterForProvisionalNotifications(System.Action)"/> in
+    /// a StartCoroutine()
     /// </remarks>
     /// <returns>true if the device was an iOS 12+ device</returns>
+    [Obsolete("Use RegisterForProvisionalNotifications(System.Action<bool>) instead.")]
     public bool RegisterForProvisionalNotifications() {
 #if !UNITY_EDITOR && UNITY_IPHONE
-        return TeakRequestPushAuthorizationUnity(true, "nocallback");
+        StartCoroutine(this.RegisterForProvisionalNotifications(null));
+        return true;
 #else
         return false;
+#endif
+    }
+
+    /// <summary>
+    /// Register for Provisional Push Notifications.
+    /// </summary>
+    /// <remarks>
+    /// This is a Coroutine and will not return until the player grants or denies push permissions.
+    /// This method only has any effect on iOS devices running iOS 12 or higher.
+    /// </remarks>
+    /// <param name="callback">The callback will be called with true if the player granted
+    /// push permissions and false if the player denied push permissions.</param>
+    public IEnumerator RegisterForProvisionalNotifications(System.Action<bool> callback) {
+#if UNITY_EDITOR
+        yield return null;
+#elif UNITY_IPHONE
+        bool keepWaiting = true;
+        string callbackId = DateTime.Now.Ticks.ToString();
+        teakOperationCallbackMap.Add(callbackId, json => {
+            if (callback != null) {
+                callback(json.ContainsKey("permissionGranted") && json["permissionGranted"] is bool && (bool)json["permissionGranted"]);
+            }
+            keepWaiting = false;
+        });
+        TeakRequestPushAuthorizationUnity(true, callbackId);
+        while (keepWaiting) { yield return null; }
+#else
+        yield return null;
 #endif
     }
 

--- a/docs/modules/changelog/unreleased.yaml
+++ b/docs/modules/changelog/unreleased.yaml
@@ -2,3 +2,6 @@ new:
   - The iOS build post-processor callback order is now configurable in Teak Settings, allowing resolution of ordering conflicts with other post-processors such as Crashlytics.
 enhancement:
   - "``TeakLogEvent`` now exposes ``DeviceId``, ``AppId``, ``BundleId``, ``SdkVersion``, ``ClientAppVersion``, and ``ClientAppVersionName`` properties from the native log payload"
+  - "``RegisterForProvisionalNotifications`` now has a coroutine overload that accepts a callback, matching the ``RegisterForNotifications`` pattern"
+deprecation:
+  - "``RegisterForProvisionalNotifications()`` (no-arg form) is deprecated in favor of ``RegisterForProvisionalNotifications(System.Action<bool>)``"


### PR DESCRIPTION
## Summary
- Add `RegisterForProvisionalNotifications(Action<bool>)` coroutine overload matching the existing `RegisterForNotifications(Action<bool>)` pattern
- Deprecate the old no-arg `RegisterForProvisionalNotifications()` (preserved for backwards compatibility)
- No native SDK changes needed — `TeakRequestPushAuthorizationUnity` already supports callbacks for both provisional and non-provisional authorization

Closes #84

## Test plan
- [ ] iOS 12+ device: call `RegisterForProvisionalNotifications(granted => Debug.Log(granted))` and verify callback fires with `true`
- [ ] Verify deprecated no-arg form still compiles and works (fires callback with `null`)
- [ ] Verify non-iOS platforms yield immediately without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)