### PR TITLE
Expose DeviceId on ConfigurationData and UserData classes

### DIFF
--- a/Assets/Teak/Teak.UserData.cs
+++ b/Assets/Teak/Teak.UserData.cs
@@ -27,6 +27,9 @@ public partial class Teak {
         /// <summary>Push registration information for the current user, if available.</summary>
         public Dictionary<string, object> PushRegistration { get; private set; }
 
+        /// <summary>The device's persistent random identifier.</summary>
+        public string DeviceId { get; private set; }
+
         private static Dictionary<string, object> EmptyDictionary = new Dictionary<string, object>();
 
         internal UserData(Dictionary<string, object> json) {
@@ -35,6 +38,7 @@ public partial class Teak {
             this.PushStatus = new Channel.Status(json.Opt("pushStatus", EmptyDictionary) as Dictionary<string, object>);
             this.SmsStatus = new Channel.Status(json.Opt("smsStatus", EmptyDictionary) as Dictionary<string, object>);
             this.PushRegistration = json.Opt("pushRegistration", EmptyDictionary) as Dictionary<string, object>;
+            this.DeviceId = json.Opt("deviceId") as string;
         }
 
 
@@ -47,6 +51,7 @@ public partial class Teak {
             dict.Add("pushStatus", this.PushStatus.ToDictionary());
             dict.Add("smsStatus", this.SmsStatus.ToDictionary());
             dict.Add("pushRegistration", this.PushRegistration);
+            dict.Add("deviceId", this.DeviceId);
             return dict;
         }
     }

--- a/Assets/Teak/Teak.cs
+++ b/Assets/Teak/Teak.cs
@@ -287,6 +287,9 @@ public partial class Teak : MonoBehaviour {
         /// </summary>
         public List<Channel.Category> ChannelCategories { get; private set; }
 
+        /// <summary>The device's persistent random identifier.</summary>
+        public string DeviceId { get; private set; }
+
         /// @cond hide_from_doxygen
         public ConfigurationData(Dictionary<string, object> json) {
             if(json.ContainsKey("channelCategories")) {
@@ -295,6 +298,7 @@ public partial class Teak : MonoBehaviour {
                     this.ChannelCategories = Teak.Utils.ParseChannelCategories(categories);
                 }
             }
+            this.DeviceId = json.ContainsKey("deviceId") ? json["deviceId"] as string : null;
         }
         /// @endcond
     }

--- a/docs/modules/changelog/unreleased.yaml
+++ b/docs/modules/changelog/unreleased.yaml
@@ -1,5 +1,6 @@
 new:
   - The iOS build post-processor callback order is now configurable in Teak Settings, allowing resolution of ordering conflicts with other post-processors such as Crashlytics.
+  - "``ConfigurationData.DeviceId`` and ``UserData.DeviceId`` expose the device's persistent random identifier for device-targeted notifications"
 enhancement:
   - "``TeakLogEvent`` now exposes ``DeviceId``, ``AppId``, ``BundleId``, ``SdkVersion``, ``ClientAppVersion``, and ``ClientAppVersionName`` properties from the native log payload"
   - "``RegisterForProvisionalNotifications`` now has a coroutine overload that accepts a callback, matching the ``RegisterForNotifications`` pattern"


### PR DESCRIPTION
## Summary
- Add `DeviceId` string property to `ConfigurationData` — parsed from `deviceId` key in the native JSON payload
- Add `DeviceId` string property to `UserData` — same key, also included in `ToDictionary()` output
- Surfaces the device's persistent random identifier so integrators can target push notifications to specific devices (multi-device play)

Closes #102

## Test plan
- [ ] Verify `ConfigurationData.DeviceId` returns the device ID from `OnConfigurationData` callback (requires native SDK with GoCarrot/teak-android#130 and GoCarrot/teak-ios#92)
- [ ] Verify `UserData.DeviceId` returns the same value from `OnUserData` callback
- [ ] Verify `UserData.ToDictionary()` includes the `deviceId` key
- [ ] Confirm existing properties on both classes are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)