### PR TITLE
Set minimum Unity version to 2022.3

### DIFF
--- a/Assets/Teak/Editor/TeakPreProcessDefiner.cs
+++ b/Assets/Teak/Editor/TeakPreProcessDefiner.cs
@@ -27,13 +27,8 @@ class TeakPreProcessDefiner : IPreprocessBuildWithReport {
     };
 
     public void OnPreprocessBuild(BuildReport report) {
-#if UNITY_2022_2_OR_NEWER
         NamedBuildTarget buildTargetGroup = NamedBuildTarget.FromBuildTargetGroup(report.summary.platformGroup);
         string[] existingDefines = PlayerSettings.GetScriptingDefineSymbols(buildTargetGroup).Split(';');
-#else
-        BuildTargetGroup buildTargetGroup = report.summary.platformGroup;
-        string[] existingDefines = PlayerSettings.GetScriptingDefineSymbolsForGroup(buildTargetGroup).Split(';');
-#endif
 
         HashSet<string> updatedDefines = new HashSet<string>(existingDefines);
         updatedDefines.RemoveWhere(define => define.StartsWith("TEAK_") && define.EndsWith("_OR_NEWER"));
@@ -41,11 +36,7 @@ class TeakPreProcessDefiner : IPreprocessBuildWithReport {
 
         string[] defines = new string[updatedDefines.Count];
         updatedDefines.CopyTo(defines);
-#if UNITY_2022_2_OR_NEWER
         PlayerSettings.SetScriptingDefineSymbols(buildTargetGroup, string.Join(";", defines));
-#else
-        PlayerSettings.SetScriptingDefineSymbolsForGroup(buildTargetGroup, string.Join(";", defines));
-#endif
     }
 }
 

--- a/Assets/Teak/Editor/TeakXcodeProjectMutator.cs
+++ b/Assets/Teak/Editor/TeakXcodeProjectMutator.cs
@@ -27,11 +27,7 @@ public class TeakXcodeProjectMutator : IPostprocessBuildWithReport {
         PBXProject project = new PBXProject();
         project.ReadFromFile(projectPath);
 
-#if UNITY_2019_3_OR_NEWER
         string unityTarget = project.GetUnityMainTargetGuid();
-#else
-        string unityTarget = project.TargetGuidByName(PBXProject.GetUnityTargetName());
-#endif
 
         /////
         // Add Frameworks to Unity target
@@ -165,11 +161,7 @@ public class TeakXcodeProjectMutator : IPostprocessBuildWithReport {
             return extensionTarget;
         }
 
-#if UNITY_2022_2_OR_NEWER
         string applicationIdentifier = PlayerSettings.GetApplicationIdentifier(NamedBuildTarget.iOS);
-#else
-        string applicationIdentifier = PlayerSettings.GetApplicationIdentifier(BuildTargetGroup.iOS);
-#endif
 
         /////
         // Create app extension target

--- a/Templates/package.json.template
+++ b/Templates/package.json.template
@@ -2,7 +2,7 @@
     "name": "io.teak.unity.sdk",
     "displayName": "Teak SDK",
     "version": "{{teak_sdk_version}}",
-    "unity": "2018.3",
+    "unity": "2022.3",
     "description": "Teak SDK for Unity.",
     "changelogUrl": "https://docs.teak.io/unity/latest/changelog/changelog.html",
     "documentationUrl": "https://docs.teak.io/unity/latest/before-you-start.html",

--- a/docs/modules/changelog/unreleased.yaml
+++ b/docs/modules/changelog/unreleased.yaml
@@ -3,5 +3,7 @@ new:
 enhancement:
   - "``TeakLogEvent`` now exposes ``DeviceId``, ``AppId``, ``BundleId``, ``SdkVersion``, ``ClientAppVersion``, and ``ClientAppVersionName`` properties from the native log payload"
   - "``RegisterForProvisionalNotifications`` now has a coroutine overload that accepts a callback, matching the ``RegisterForNotifications`` pattern"
+breaking:
+  - "Minimum Unity version is now 2022.3 (previously 2018.3)"
 deprecation:
   - "``RegisterForProvisionalNotifications()`` (no-arg form) is deprecated in favor of ``RegisterForProvisionalNotifications(System.Action<bool>)``"


### PR DESCRIPTION
## Summary
- Update UPM `package.json.template` minimum from `2018.3` to `2022.3` (required for xcframework support)
- Remove three dead `#if` guard pairs that are always true at the new minimum:
  - `UNITY_2019_3_OR_NEWER` in `TeakXcodeProjectMutator.cs` (`GetUnityMainTargetGuid` vs `TargetGuidByName`)
  - `UNITY_2022_2_OR_NEWER` in `TeakXcodeProjectMutator.cs` (`NamedBuildTarget` vs `BuildTargetGroup`)
  - `UNITY_2022_2_OR_NEWER` in `TeakPreProcessDefiner.cs` (same API pair, x2)
- Two `UNITY_2023_1_OR_NEWER` guards in `Teak.cs` are intentionally kept (they still gate real API differences)

Closes #115

## Test plan
- [ ] Verify `rake upm:build` produces a package with `"unity": "2022.3"` in `package.json`
- [ ] iOS build succeeds (Xcode post-processor still correctly resolves target GUID and app identifier)
- [ ] Build pre-process defines are still injected correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)