### PR TITLE
Replace libTeak.a with Teak.xcframework in iOS plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ Assets/Teak/Plugins/Android/Version.java
 
 # Teak binaries
 Assets/Teak/Plugins/Android/teak.aar
-Assets/Teak/Plugins/iOS/libTeak.a
+Assets/Teak/Plugins/iOS/Teak.xcframework/
 
 # Teak resources
 Assets/Teak/Plugins/iOS/TeakResources.bundle

--- a/Assets/Teak/Plugins/iOS/Teak.xcframework.meta
+++ b/Assets/Teak/Plugins/iOS/Teak.xcframework.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6
+guid: 96f42976fdd64c9c8b3da86900494e8d
 folderAsset: yes
 PluginImporter:
   externalObjects: {}
@@ -118,7 +118,7 @@ PluginImporter:
     second:
       enabled: 1
       settings:
-        AddToEmbeddedBinaries: false
+        AddToEmbeddedBinaries: true
         FrameworkDependencies: AdSupport;AVFoundation;CoreServices;StoreKit;UserNotifications;ImageIO;CoreGraphics;UIKit;SystemConfiguration
   userData:
   assetBundleName:

--- a/Assets/Teak/Plugins/iOS/Teak.xcframework.meta
+++ b/Assets/Teak/Plugins/iOS/Teak.xcframework.meta
@@ -1,5 +1,6 @@
 fileFormatVersion: 2
-guid: 25ea50116633044f5b3b51bebff0d0b1
+guid: a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6
+folderAsset: yes
 PluginImporter:
   externalObjects: {}
   serializedVersion: 2
@@ -35,7 +36,7 @@ PluginImporter:
       settings:
         CPU: ARMv7
   - first:
-      Any: 
+      Any:
     second:
       enabled: 0
       settings: {}
@@ -117,7 +118,8 @@ PluginImporter:
     second:
       enabled: 1
       settings:
+        AddToEmbeddedBinaries: false
         FrameworkDependencies: AdSupport;AVFoundation;CoreServices;StoreKit;UserNotifications;ImageIO;CoreGraphics;UIKit;SystemConfiguration
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Rakefile
+++ b/Rakefile
@@ -51,6 +51,42 @@ def build_local?
   ENV.fetch('BUILD_LOCAL', false).to_s == 'true'
 end
 
+require 'securerandom'
+
+def generate_meta_files(dir)
+  Dir.glob(File.join(dir, '**', '*')).each do |entry|
+    meta_path = "#{entry}.meta"
+    next if entry.end_with?('.meta')
+    next if File.exist?(meta_path)
+
+    guid = SecureRandom.hex(16)
+    is_dir = File.directory?(entry)
+    content = if is_dir
+                <<~META
+                  fileFormatVersion: 2
+                  guid: #{guid}
+                  folderAsset: yes
+                  DefaultImporter:
+                    externalObjects: {}
+                    userData:
+                    assetBundleName:
+                    assetBundleVariant:
+                META
+              else
+                <<~META
+                  fileFormatVersion: 2
+                  guid: #{guid}
+                  DefaultImporter:
+                    externalObjects: {}
+                    userData:
+                    assetBundleName:
+                    assetBundleVariant:
+                META
+              end
+    File.write(meta_path, content)
+  end
+end
+
 task default: ['build:android', 'build:ios', 'build:package']
 
 def unity_path
@@ -155,6 +191,9 @@ namespace :build do
         end
       end
     end
+
+    # Generate .meta files for xcframework contents (required by UnityPackage)
+    generate_meta_files(xcframework_dest)
 
     # Download or copy Teak SDK Resources bundle
     Dir.mktmpdir do |dir|

--- a/Rakefile
+++ b/Rakefile
@@ -97,7 +97,7 @@ namespace :version do
     )
     bucket = s3.bucket('teak-build-artifacts')
 
-    fail "Teak iOS version #{args.v} does not exist" unless bucket.object("ios/Teak-#{args.v}.framework.zip").exists?
+    fail "Teak iOS version #{args.v} does not exist" unless bucket.object("ios/Teak-#{args.v}.xcframework.zip").exists?
 
     NATIVE_CONFIG['version']['ios'] = args.v
     File.write('native.config.yml', NATIVE_CONFIG.to_yaml)
@@ -139,15 +139,19 @@ namespace :build do
   end
 
   task :ios do
-    # Download or copy Teak SDK
+    ios_plugin_dir = File.join(PROJECT_PATH, 'Assets', 'Teak', 'Plugins', 'iOS')
+    xcframework_dest = File.join(ios_plugin_dir, 'Teak.xcframework')
+
+    # Download or copy Teak SDK xcframework
+    FileUtils.rm_rf(xcframework_dest)
     if build_local?
-      cp "#{PROJECT_PATH}/../teak-ios/build/#{BUILD_TYPE}-iphoneos/libTeak.a", File.join(PROJECT_PATH, 'Assets', 'Teak', 'Plugins', 'iOS', 'libTeak.a')
+      FileUtils.cp_r("#{PROJECT_PATH}/../teak-ios/TeakFramework/Teak.xcframework", xcframework_dest)
     else
       Dir.mktmpdir do |dir|
         Dir.chdir(dir) do
-          sh "curl --fail -o Teak.framework.zip https://sdks.teakcdn.com/ios/Teak-#{NATIVE_CONFIG['version']['ios']}.framework.zip"
-          sh 'unzip Teak.framework.zip'
-          cp 'Teak.framework/Teak', File.join(PROJECT_PATH, 'Assets', 'Teak', 'Plugins', 'iOS', 'libTeak.a')
+          sh "curl --fail -o Teak.xcframework.zip https://sdks.teakcdn.com/ios/Teak-#{NATIVE_CONFIG['version']['ios']}.xcframework.zip"
+          sh 'unzip Teak.xcframework.zip'
+          FileUtils.cp_r('Teak.xcframework', xcframework_dest)
         end
       end
     end

--- a/native.config.yml
+++ b/native.config.yml
@@ -1,4 +1,4 @@
 ---
 version:
-  ios: 4.3.2
+  ios: 4.3.10-beta2
   android: 4.3.9


### PR DESCRIPTION
## Summary
- Switch `build:ios` Rake task from downloading legacy `Teak.framework.zip` (extracting binary as `libTeak.a`) to downloading `Teak.xcframework.zip` and placing the full xcframework directory bundle
- Update `BUILD_LOCAL=true` path to copy from `../teak-ios/TeakFramework/Teak.xcframework/`
- Update `version:ios` S3 existence check to look for `.xcframework.zip`
- Remove `libTeak.a.meta`, add `Teak.xcframework.meta` with iOS platform targeting and framework dependencies
- Bump native iOS SDK version to `4.3.10-beta2`

## Test plan
- [x] `bundle exec rake build:ios` downloads xcframework from CDN and places it correctly
- [x] `BUILD_LOCAL=true bundle exec rake build:ios` copies xcframework from local teak-ios checkout
- [x] Verified xcframework contains device (arm64) and simulator (arm64 + x86_64) slices
- [ ] Unity import verification (deferred — full Xcode build testing comes with #117)

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)