### PR TITLE
Cache rbenv Ruby installation in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ references:
   RUBY_IMAGE: &RUBY_IMAGE
     cimg/ruby:3.1.6
   MACOS_CACHE_KEY: &MACOS_CACHE_KEY
-    v1-{{ checksum "setup" }}-{{ checksum "Gemfile.lock" }}
+    v2-{{ checksum "setup" }}-{{ checksum ".ruby-version" }}-{{ checksum "Gemfile.lock" }}
   RUBY_CACHE_KEY: &RUBY_CACHE_KEY
     v0-{{ checksum "Gemfile.lock" }}
 
@@ -42,6 +42,7 @@ jobs:
           paths:
             - ~/Library/Caches/Homebrew
             - vendor/bundle
+            - ~/.rbenv/versions
           key: *MACOS_CACHE_KEY
       - run:
           name: Build Teak SDK


### PR DESCRIPTION
## Summary
- Add `~/.rbenv/versions` to CircleCI `save_cache` paths so Ruby 3.1.6 isn't compiled from source on every build
- Include `.ruby-version` in cache key to invalidate when Ruby version changes
- Bump cache key version to `v2` to start fresh

This should cut several minutes off every CI build.

Closes #123

## Test plan
- [ ] First CI run: cache miss, compiles Ruby, saves to cache (slow as usual)
- [ ] Second CI run: cache hit, skips Ruby compilation (fast)

🤖 Generated with [Claude Code](https://claude.com/claude-code)