### PR TITLE
Update TeakXcodeProjectMutator for xcframework linking

### DIFF
--- a/Assets/Teak/Editor/TeakXcodeProjectMutator.cs
+++ b/Assets/Teak/Editor/TeakXcodeProjectMutator.cs
@@ -204,7 +204,7 @@ public class TeakXcodeProjectMutator : IPostprocessBuildWithReport {
         project.AddFrameworksToTarget(extensionTarget, frameworks);
 
         /////
-        // Add libTeak.a
+        // Link Teak.xcframework
 
         // If the 'Runtime' directory exists, this is coming from a UPM package
         string pathToCheck = Path.GetDirectoryName(Path.GetDirectoryName(__FILE__));
@@ -212,9 +212,12 @@ public class TeakXcodeProjectMutator : IPostprocessBuildWithReport {
         if (Directory.Exists(pathToCheck + "/Runtime")) {
             relativeTeakPath = "io.teak.unity.sdk/Runtime";
         }
-        project.AddFileToBuild(extensionTarget, project.AddFile("libTeak.a", name + "/libTeak.a"));
-        project.AddBuildProperty(extensionTarget, "LIBRARY_SEARCH_PATHS", "$(SRCROOT)/Libraries/" + relativeTeakPath + "/Plugins/iOS");
-        project.AddBuildProperty(extensionTarget, "ALWAYS_SEARCH_USER_PATHS", "NO");
+        string xcframeworkProjectPath = "Libraries/" + relativeTeakPath + "/Plugins/iOS/Teak.xcframework";
+        string xcframeworkGuid = project.FindFileGuidByProjectPath(xcframeworkProjectPath);
+        if (string.IsNullOrEmpty(xcframeworkGuid)) {
+            xcframeworkGuid = project.AddFile(xcframeworkProjectPath, name + "/Teak.xcframework");
+        }
+        project.AddFileToBuild(extensionTarget, xcframeworkGuid);
 
         /////
         // Build properties

--- a/Assets/Teak/Editor/TeakXcodeProjectMutator.cs
+++ b/Assets/Teak/Editor/TeakXcodeProjectMutator.cs
@@ -215,7 +215,7 @@ public class TeakXcodeProjectMutator : IPostprocessBuildWithReport {
         string xcframeworkProjectPath = "Libraries/" + relativeTeakPath + "/Plugins/iOS/Teak.xcframework";
         string xcframeworkGuid = project.FindFileGuidByProjectPath(xcframeworkProjectPath);
         if (string.IsNullOrEmpty(xcframeworkGuid)) {
-            xcframeworkGuid = project.AddFile(xcframeworkProjectPath, name + "/Teak.xcframework");
+            xcframeworkGuid = project.AddFile(xcframeworkProjectPath, xcframeworkProjectPath);
         }
         project.AddFileToBuild(extensionTarget, xcframeworkGuid);
 


### PR DESCRIPTION
## Summary
- Replace `libTeak.a` static library linking with `Teak.xcframework` linking in the Xcode post-processor
- Extension targets now find the xcframework reference Unity added to the project and link against it
- Remove `LIBRARY_SEARCH_PATHS` and `ALWAYS_SEARCH_USER_PATHS` (not needed with xcframework linking)
- Preserve UPM path detection for locating the xcframework

Depends on: #122 (merged)
Closes #117

## Test plan
- [ ] iOS build from Unity generates Xcode project with xcframework linked to extension targets
- [ ] Both UPM and .unitypackage layouts produce correct Xcode projects
- [ ] Full integration testing after #118 and #119 are complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)