### PR TITLE
Add Force Debug Output setting with build post-processing

### DIFF
--- a/Assets/Teak/Editor/TeakAndroidAssetLibBuilder.cs
+++ b/Assets/Teak/Editor/TeakAndroidAssetLibBuilder.cs
@@ -31,12 +31,8 @@ public class TeakAndroidAssetLibBuilder : IPreprocessBuildWithReport {
         Directory.CreateDirectory(Path.Combine(Application.dataPath, androidLibPath, "res/values"));
 
         // res/values/teak.xml
-        XDocument doc = new XDocument(
-            new XElement("resources",
-                         new XElement("string", TeakSettings.AppId, new XAttribute("name", "io_teak_app_id")),
-                         new XElement("string", TeakSettings.APIKey, new XAttribute("name", "io_teak_api_key"))
-                        )
-        );
+        bool forceDebugOutput = TeakSettings.ForceDebugOutput || UnityEngine.Debug.isDebugBuild;
+        XDocument doc = BuildTeakResourcesXml(TeakSettings.AppId, TeakSettings.APIKey, forceDebugOutput);
         doc.Save(Path.Combine(Application.dataPath, androidLibPath, "res/values/teak.xml"));
 
         // project.properties
@@ -57,6 +53,19 @@ public class TeakAndroidAssetLibBuilder : IPreprocessBuildWithReport {
         AssetDatabase.Refresh(ImportAssetOptions.ForceUpdate);
         AssetDatabase.Refresh(ImportAssetOptions.ImportRecursive);
         AssetDatabase.SaveAssets();
+    }
+
+    internal static XDocument BuildTeakResourcesXml(string appId, string apiKey, bool forceDebugOutput) {
+        XElement resources = new XElement("resources",
+            new XElement("string", appId, new XAttribute("name", "io_teak_app_id")),
+            new XElement("string", apiKey, new XAttribute("name", "io_teak_api_key"))
+        );
+
+        if (forceDebugOutput) {
+            resources.Add(new XElement("bool", "true", new XAttribute("name", "io_teak_force_debug_output")));
+        }
+
+        return new XDocument(resources);
     }
 }
 

--- a/Assets/Teak/Editor/TeakSettingsEditor.cs
+++ b/Assets/Teak/Editor/TeakSettingsEditor.cs
@@ -40,6 +40,9 @@ public class TeakSettingsEditor : Editor {
         GUIContent sdk5BehaviorsContent = new GUIContent("Enable SDK 5 Behaviors [?]",  "When enabled, the Teak SDK will no longer automatically collect the Facebook Access Token from signed-in users.");
         TeakSettings.EnableSDK5Behaviors = EditorGUILayout.Toggle(sdk5BehaviorsContent, TeakSettings.EnableSDK5Behaviors);
 
+        GUIContent forceDebugOutputContent = new GUIContent("Force Debug Output [?]", "When enabled (or in Development Builds), forces verbose Teak SDK logging on-device regardless of server configuration. Useful for QA/staging builds.");
+        TeakSettings.ForceDebugOutput = EditorGUILayout.Toggle(forceDebugOutputContent, TeakSettings.ForceDebugOutput);
+
         GUIContent iOSCallbackOrderContent = new GUIContent("iOS Post-Processor Order [?]", "The callbackOrder for the iOS build post-processor. Change this to control when Teak's Xcode project modifications run relative to other post-processors. Default is 100.");
         TeakSettings.iOSBuildPostProcessorCallbackOrder = EditorGUILayout.IntField(iOSCallbackOrderContent, TeakSettings.iOSBuildPostProcessorCallbackOrder);
     }

--- a/Assets/Teak/Editor/TeakXcodeProjectMutator.cs
+++ b/Assets/Teak/Editor/TeakXcodeProjectMutator.cs
@@ -90,6 +90,9 @@ public class TeakXcodeProjectMutator : IPostprocessBuildWithReport {
         // SDK5 Behaviors
         plist.root.SetBoolean("TeakSDK5Behaviors", TeakSettings.EnableSDK5Behaviors);
 
+        // Force debug output
+        plist.root.SetBoolean("TeakForceDebugOutput", TeakSettings.ForceDebugOutput || UnityEngine.Debug.isDebugBuild);
+
         return plist.WriteToString();
     }
 

--- a/Assets/Teak/TeakSettings.cs
+++ b/Assets/Teak/TeakSettings.cs
@@ -114,6 +114,18 @@ public class TeakSettings : ScriptableObject {
 #endif
     }
 
+    public static bool ForceDebugOutput {
+        get { return Instance.mForceDebugOutput; }
+#if UNITY_EDITOR
+        set {
+            if (value != Instance.mForceDebugOutput) {
+                Instance.mForceDebugOutput = value;
+                DirtyEditor();
+            }
+        }
+#endif
+    }
+
     public static int iOSBuildPostProcessorCallbackOrder {
         get { return Instance.miOSBuildPostProcessorCallbackOrder; }
 #if UNITY_EDITOR
@@ -149,6 +161,8 @@ public class TeakSettings : ScriptableObject {
     private bool mEnableSDK5Behaviors = true;
     [SerializeField]
     private bool mTraceLogging = false;
+    [SerializeField]
+    private bool mForceDebugOutput = false;
     [SerializeField]
     private int miOSBuildPostProcessorCallbackOrder = 100;
 

--- a/Assets/Tests/Editor/TeakAndroidAssetLibBuilderTests.cs
+++ b/Assets/Tests/Editor/TeakAndroidAssetLibBuilderTests.cs
@@ -1,0 +1,29 @@
+using System.Xml.Linq;
+
+[TeakTestFixture]
+public class TeakAndroidAssetLibBuilderTests {
+
+    [TeakTest]
+    public void ForceDebugOutputTrue_IncludesBoolElement() {
+        XDocument doc = TeakAndroidAssetLibBuilder.BuildTeakResourcesXml("app-id", "api-key", true);
+        string xml = doc.ToString();
+        TeakAssert.IsTrue(xml.Contains("<bool name=\"io_teak_force_debug_output\">true</bool>"),
+            "Expected XML to contain io_teak_force_debug_output bool element set to true");
+    }
+
+    [TeakTest]
+    public void ForceDebugOutputFalse_OmitsBoolElement() {
+        XDocument doc = TeakAndroidAssetLibBuilder.BuildTeakResourcesXml("app-id", "api-key", false);
+        string xml = doc.ToString();
+        TeakAssert.IsFalse(xml.Contains("io_teak_force_debug_output"),
+            "Expected XML to NOT contain io_teak_force_debug_output when false");
+    }
+
+    [TeakTest]
+    public void AppIdAndApiKeyPresent() {
+        XDocument doc = TeakAndroidAssetLibBuilder.BuildTeakResourcesXml("my-app", "my-key", false);
+        string xml = doc.ToString();
+        TeakAssert.IsTrue(xml.Contains("my-app"), "Expected XML to contain app id");
+        TeakAssert.IsTrue(xml.Contains("my-key"), "Expected XML to contain api key");
+    }
+}

--- a/Assets/Tests/Editor/TeakAndroidAssetLibBuilderTests.cs.meta
+++ b/Assets/Tests/Editor/TeakAndroidAssetLibBuilderTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: db44c822ee4cd4a44ac3760a6f8ab726

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,16 @@ bundle exec rake format
 yarn docs
 ```
 
-There is no automated test suite in this repository.
+**Running tests:**
+```bash
+# Via Unity CLI (project version: see ProjectSettings/ProjectVersion.txt)
+/Applications/Unity/Hub/Editor/<VERSION>/Unity.app/Contents/MacOS/Unity \
+  -executeMethod TeakTestRunner.RunAll \
+  -logFile unity.test.log -quit -nographics -batchmode \
+  -projectPath .
+```
+
+Tests use a custom runner (`Assets/Tests/Editor/TeakTestRunner.cs`) with `[TeakTestFixture]` / `[TeakTest]` attributes and `TeakAssert` helpers. Test files live in `Assets/Tests/Editor/`. Since there are no `.asmdef` files, all Editor scripts (including build post-processors) compile into `Assembly-CSharp-Editor`, so tests can access `internal` members directly.
 
 ## Architecture
 

--- a/docs/modules/changelog/unreleased.yaml
+++ b/docs/modules/changelog/unreleased.yaml
@@ -1,6 +1,7 @@
 new:
   - The iOS build post-processor callback order is now configurable in Teak Settings, allowing resolution of ordering conflicts with other post-processors such as Crashlytics.
   - "``ConfigurationData.DeviceId`` and ``UserData.DeviceId`` expose the device's persistent random identifier for device-targeted notifications"
+  - "Added Force Debug Output toggle to Teak Settings. When enabled (or in Development Builds), forces verbose SDK logging on-device regardless of server configuration."
 enhancement:
   - "``TeakLogEvent`` now exposes ``DeviceId``, ``AppId``, ``BundleId``, ``SdkVersion``, ``ClientAppVersion``, and ``ClientAppVersionName`` properties from the native log payload"
   - "``RegisterForProvisionalNotifications`` now has a coroutine overload that accepts a callback, matching the ``RegisterForNotifications`` pattern"


### PR DESCRIPTION
## Summary

Closes #109.

- Adds a **Force Debug Output** toggle to Teak editor settings (Build Settings section)
- When enabled — or in Development Builds (`Debug.isDebugBuild`) — injects platform resources at build time:
  - **iOS**: `TeakForceDebugOutput = YES` in Info.plist
  - **Android**: `<bool name="io_teak_force_debug_output">true</bool>` in `res/values/teak.xml`
- Extracts Android XML generation into testable `BuildTeakResourcesXml` method
- Adds 3 tests via the TeakTestRunner harness (all 11 tests pass)
- Updates CLAUDE.md to document the test harness

## Test plan

- [x] All 11 TeakTestRunner tests pass (3 new + 8 existing)
- [ ] Verify toggle appears in Edit → Teak Settings under Build Settings
- [ ] Android build: inspect generated `res/values/teak.xml` for `io_teak_force_debug_output`
- [ ] iOS build: inspect generated Info.plist for `TeakForceDebugOutput`
- [ ] Development build auto-enables force debug output even when toggle is off

🤖 Generated with [Claude Code](https://claude.com/claude-code)