### PR TITLE
Fix xcframework lookup path in Xcode post-processor

### DIFF
--- a/Assets/Teak/Editor/TeakXcodeProjectMutator.cs
+++ b/Assets/Teak/Editor/TeakXcodeProjectMutator.cs
@@ -212,7 +212,8 @@ public class TeakXcodeProjectMutator : IPostprocessBuildWithReport {
         if (Directory.Exists(pathToCheck + "/Runtime")) {
             relativeTeakPath = "io.teak.unity.sdk/Runtime";
         }
-        string xcframeworkProjectPath = "Libraries/" + relativeTeakPath + "/Plugins/iOS/TeakExtension.xcframework";
+        // Unity places xcframeworks under Frameworks/
+        string xcframeworkProjectPath = "Frameworks/" + relativeTeakPath.TrimEnd(Path.DirectorySeparatorChar, '/') + "/Plugins/iOS/TeakExtension.xcframework";
         string xcframeworkGuid = project.FindFileGuidByProjectPath(xcframeworkProjectPath);
         if (string.IsNullOrEmpty(xcframeworkGuid)) {
             xcframeworkGuid = project.AddFile(xcframeworkProjectPath, xcframeworkProjectPath);


### PR DESCRIPTION
## Summary

Unity places xcframeworks under `Frameworks/` in the generated Xcode project, but the post-processor was hardcoded to look under `Libraries/`. This caused:

- `FindFileGuidByProjectPath` to miss the existing reference
- A duplicate `TeakExtension.xcframework` file reference at a non-existent `Libraries/` path
- Xcode build failure: "There is no XCFramework found at ..."

Also fixes a double-slash in the path (`Libraries/Teak//Plugins/iOS/...`) caused by a trailing separator on `relativeTeakPath`.

## Test plan

- [x] Cleanroom iOS build succeeds with xcframeworks resolved correctly
- [ ] Verify no duplicate xcframework references in generated pbxproj
- [ ] Verify extension targets link against the correct xcframework

🤖 Generated with [Claude Code](https://claude.com/claude-code)