### PR TITLE
Fix Debug.isDebugBuild always true in iOS build post-processor

### DIFF
--- a/Assets/Teak/Editor/TeakXcodeProjectMutator.cs
+++ b/Assets/Teak/Editor/TeakXcodeProjectMutator.cs
@@ -23,6 +23,8 @@ public class TeakXcodeProjectMutator : IPostprocessBuildWithReport {
         if (TeakSettings.JustShutUpIKnowWhatImDoing) { return; }
         if (report.summary.platformGroup != BuildTargetGroup.iOS) { return; }
 
+        bool isDevelopmentBuild = (report.summary.options & BuildOptions.Development) != 0;
+
         string projectPath = PBXProject.GetPBXProjectPath(report.summary.outputPath);
         PBXProject project = new PBXProject();
         project.ReadFromFile(projectPath);
@@ -45,7 +47,7 @@ public class TeakXcodeProjectMutator : IPostprocessBuildWithReport {
         /////
         // Modify plist
         string plistPath = report.summary.outputPath + "/Info.plist";
-        File.WriteAllText(plistPath, AddTeakEntriesToPlist(File.ReadAllText(plistPath)));
+        File.WriteAllText(plistPath, AddTeakEntriesToPlist(File.ReadAllText(plistPath), isDevelopmentBuild));
 
         /////
         // Add Teak app extensions
@@ -68,12 +70,12 @@ public class TeakXcodeProjectMutator : IPostprocessBuildWithReport {
         string unityTargetName = "Unity-iPhone";
         string entitlementsFileName = unityTargetName + ".entitlements";
         ProjectCapabilityManager capabilityManager = new ProjectCapabilityManager(projectPath, entitlementsFileName, unityTargetName);
-        capabilityManager.AddPushNotifications(UnityEngine.Debug.isDebugBuild);
+        capabilityManager.AddPushNotifications(isDevelopmentBuild);
         capabilityManager.AddAssociatedDomains(new string[] {"applinks:" + TeakSettings.ShortlinkDomain});
         capabilityManager.WriteToFile();
     }
 
-    private static string AddTeakEntriesToPlist(string inputPlist) {
+    private static string AddTeakEntriesToPlist(string inputPlist, bool isDevelopmentBuild) {
         PlistDocument plist = new PlistDocument();
         plist.ReadFromString(inputPlist);
 
@@ -91,7 +93,7 @@ public class TeakXcodeProjectMutator : IPostprocessBuildWithReport {
         plist.root.SetBoolean("TeakSDK5Behaviors", TeakSettings.EnableSDK5Behaviors);
 
         // Force debug output
-        plist.root.SetBoolean("TeakForceDebugOutput", TeakSettings.ForceDebugOutput || UnityEngine.Debug.isDebugBuild);
+        plist.root.SetBoolean("TeakForceDebugOutput", TeakSettings.ForceDebugOutput || isDevelopmentBuild);
 
         return plist.WriteToString();
     }

--- a/Assets/Teak/TeakLogEvent.cs
+++ b/Assets/Teak/TeakLogEvent.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using MiniJSON.Teak;
 
 /// <summary>
 /// Describes a semi-structured log event that is reported from the native Teak SDK.
@@ -50,8 +51,8 @@ public class TeakLogEvent {
     /// <summary>The application bundle identifier, if present in the log payload.</summary>
     public string BundleId { get; private set; }
 
-    /// <summary>The native Teak SDK version, if present in the log payload.</summary>
-    public string SdkVersion { get; private set; }
+    /// <summary>The Teak SDK version info, keyed by platform (e.g. "ios", "android", "unity").</summary>
+    public Dictionary<string, object> SdkVersion { get; private set; }
 
     /// <summary>The client application version code, if present in the log payload.</summary>
     public string ClientAppVersion { get; private set; }
@@ -71,7 +72,7 @@ public class TeakLogEvent {
         this.DeviceId = logData.ContainsKey("device_id") ? logData["device_id"] as string : null;
         this.AppId = logData.ContainsKey("app_id") ? logData["app_id"] as string : null;
         this.BundleId = logData.ContainsKey("bundle_id") ? logData["bundle_id"] as string : null;
-        this.SdkVersion = logData.ContainsKey("sdk_version") ? logData["sdk_version"] as string : null;
+        this.SdkVersion = logData.ContainsKey("sdk_version") ? logData["sdk_version"] as Dictionary<string, object> : null;
         this.ClientAppVersion = logData.ContainsKey("client_app_version") ? logData["client_app_version"] as string : null;
         this.ClientAppVersionName = logData.ContainsKey("client_app_version_name") ? logData["client_app_version_name"] as string : null;
     }
@@ -93,7 +94,7 @@ public class TeakLogEvent {
                              this.DeviceId,
                              this.AppId,
                              this.BundleId,
-                             this.SdkVersion,
+                             this.SdkVersion != null ? Json.Serialize(this.SdkVersion) : "null",
                              this.ClientAppVersion,
                              this.ClientAppVersionName,
                              eventDataString

--- a/docs/modules/changelog/unreleased.yaml
+++ b/docs/modules/changelog/unreleased.yaml
@@ -2,6 +2,8 @@ new:
   - The iOS build post-processor callback order is now configurable in Teak Settings, allowing resolution of ordering conflicts with other post-processors such as Crashlytics.
   - "``ConfigurationData.DeviceId`` and ``UserData.DeviceId`` expose the device's persistent random identifier for device-targeted notifications"
   - "Added Force Debug Output toggle to Teak Settings. When enabled (or in Development Builds), forces verbose SDK logging on-device regardless of server configuration."
+bug:
+  - "``TeakForceDebugOutput`` and push notification entitlement in iOS builds now correctly reflect the Development Build setting instead of always being enabled"
 enhancement:
   - "``TeakLogEvent`` now exposes ``DeviceId``, ``AppId``, ``BundleId``, ``SdkVersion``, ``ClientAppVersion``, and ``ClientAppVersionName`` properties from the native log payload"
   - "``RegisterForProvisionalNotifications`` now has a coroutine overload that accepts a callback, matching the ``RegisterForNotifications`` pattern"

--- a/native.config.yml
+++ b/native.config.yml
@@ -1,4 +1,4 @@
 ---
 version:
-  ios: 4.3.10-beta2
-  android: 4.3.9
+  ios: 4.3.10-beta6
+  android: 4.3.10-beta0


### PR DESCRIPTION
## Summary
- `Debug.isDebugBuild` always returns `true` when running in the Unity Editor (including batch mode builds), so `TeakForceDebugOutput` and the push notification APS entitlement were always set to development/debug values regardless of build type.
- Replaced both uses with `(report.summary.options & BuildOptions.Development) != 0` to correctly reflect the actual build configuration.

Fixes #132

## Test plan
- [ ] Build a **Development** iOS build and verify `TeakForceDebugOutput` is `true` in Info.plist and `aps-environment` is `development` in entitlements
- [ ] Build a **Release** iOS build (no Force Debug Output) and verify `TeakForceDebugOutput` is `false` and `aps-environment` is `production`
- [ ] Build a **Release** iOS build with Force Debug Output enabled in Teak Settings and verify `TeakForceDebugOutput` is `true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)