### PR TITLE
feat(C-645): Unity Live Activity SDK wrappers

### DIFF
--- a/Assets/Teak/Plugins/iOS/teak_init.m
+++ b/Assets/Teak/Plugins/iOS/teak_init.m
@@ -54,6 +54,11 @@ extern NSArray* TeakGetChannelCategories();
 // TeakNotification v2
 extern NSObject* TeakNotificationSchedulePersonalizationData(const char* creativeId, int64_t delay, const char* personalizationDataJson);
 
+// Live Activities (iOS 16.1+)
+extern NSObject* TeakStartedLiveActivity(const char* activityId, const void* pushTokenBytes, int pushTokenLength, const char* systemActivityId);
+extern NSObject* TeakScheduleLiveActivityUpdate(const char* activityId, int64_t offset, const char* customDataJson, const char* systemDataJson);
+extern NSObject* TeakCancelLiveActivityUpdates(const char* activityId);
+
 // Unity
 extern void UnitySendMessage(const char*, const char*, const char*);
 
@@ -137,6 +142,36 @@ void* TeakSetStateForCategory_Retained(const char* stateCstr, const char* channe
    return operation;
 #else
    return [TeakSetStateForCategory(stateCstr, channelCstr, categoryCstr)() retain];
+#endif
+}
+
+void* TeakStartedLiveActivity_Retained(const char* activityId, const void* pushTokenBytes, int pushTokenLength, const char* systemActivityId)
+{
+#if __has_feature(objc_arc)
+   void* operation = (__bridge_retained void*)TeakStartedLiveActivity(activityId, pushTokenBytes, pushTokenLength, systemActivityId);
+   return operation;
+#else
+   return [TeakStartedLiveActivity(activityId, pushTokenBytes, pushTokenLength, systemActivityId) retain];
+#endif
+}
+
+void* TeakScheduleLiveActivityUpdate_Retained(const char* activityId, int64_t offset, const char* customDataJson, const char* systemDataJson)
+{
+#if __has_feature(objc_arc)
+   void* operation = (__bridge_retained void*)TeakScheduleLiveActivityUpdate(activityId, offset, customDataJson, systemDataJson);
+   return operation;
+#else
+   return [TeakScheduleLiveActivityUpdate(activityId, offset, customDataJson, systemDataJson) retain];
+#endif
+}
+
+void* TeakCancelLiveActivityUpdates_Retained(const char* activityId)
+{
+#if __has_feature(objc_arc)
+   void* operation = (__bridge_retained void*)TeakCancelLiveActivityUpdates(activityId);
+   return operation;
+#else
+   return [TeakCancelLiveActivityUpdates(activityId) retain];
 #endif
 }
 

--- a/Assets/Teak/Teak.LiveActivity.cs
+++ b/Assets/Teak/Teak.LiveActivity.cs
@@ -1,0 +1,366 @@
+#region References
+/// @cond hide_from_doxygen
+using UnityEngine;
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+using MiniJSON.Teak;
+using TeakExtensions;
+/// @endcond
+#endregion
+
+public partial class Teak {
+
+    /// <summary>
+    /// Teak Live Activity functionality (iOS 16.1+).
+    /// </summary>
+    /// <remarks>
+    /// Live Activities are an iOS-only feature. All methods on this class no-op on non-iOS
+    /// platforms and on iOS versions earlier than 16.1.
+    ///
+    /// Activity-resumption attribution (taps on a Live Activity that launch the app) flows
+    /// through the existing session-attribution path on the native iOS SDK: when the app is
+    /// launched via activity resumption, the native SDK constructs a <c>TeakLiveActivityLaunchData</c>
+    /// whose session attribution carries <c>teak_live_activity_id</c>. This surfaces on the
+    /// Unity side via <see cref="Teak.OnPostLaunchSummary"/>; no explicit Unity-side API is
+    /// required to receive it.
+    /// </remarks>
+    public partial class LiveActivity {
+
+        /// <summary>Result of a call to a Live Activity API.</summary>
+        public class Reply : IToJson {
+            /// <summary>True if the call resulted in an error.</summary>
+            public bool Error {
+                get; private set;
+            }
+
+            /// <summary>A mapping of the argument or cause of the error to an array of strings explaining the errors.</summary>
+            public Dictionary<string, List<string>> Errors {
+                get; private set;
+            }
+
+            /// <summary>The number of pending updates canceled by <see cref="LiveActivity.CancelLiveActivityUpdates"/>, or null for other calls.</summary>
+            public int? CanceledCount {
+                get; private set;
+            }
+
+            /// <summary>The JSON received from the server.</summary>
+            public Dictionary<string, object> Json {
+                get; private set;
+            }
+
+            public Dictionary<string, object> toJson() {
+                return this.Json;
+            }
+
+            /// @cond hide_from_doxygen
+            public Reply(Dictionary<string, object> json) {
+                this.Json = json;
+
+                string status = json.Opt("status", "error") as string;
+                this.Error = !"ok".Equals(status);
+                this.Errors = Teak.Utils.ParseErrorsFromReply(json);
+
+                if (json.ContainsKey("canceled")) {
+                    try {
+                        this.CanceledCount = Convert.ToInt32(json["canceled"]);
+                    } catch (Exception) {
+                        this.CanceledCount = null;
+                    }
+                }
+            }
+
+            /// <summary>
+            /// Returns a string that represents the current object.
+            /// </summary>
+            /// <returns>A string that represents the current object.</returns>
+            public override string ToString() {
+                return MiniJSON.Teak.Json.Serialize(this.Json);
+            }
+
+            public static Reply ReplyWithErrorForException(Exception e) {
+                return new Reply(new Dictionary<string, object> {
+                    {"status", "error"},
+                    {
+                        "errors", new Dictionary<string, object> {
+                            {"unity", new string[] { e.ToString() }}
+                        }
+                    }
+                });
+            }
+            /// @endcond
+
+            /// <summary>Unknown Unity-related error</summary>
+            public static Reply UndeterminedUnityError = new Reply(new Dictionary<string, object> {
+                {"status", "error"},
+                {
+                    "errors", new Dictionary<string, object> {
+                        {"unity", new string[] {"Undetermined error"}}
+                    }
+                }
+            });
+        }
+
+        /// <summary>
+        /// Report a Live Activity push-to-update token to Teak.
+        /// </summary>
+        /// <remarks>
+        /// Call this when a live activity starts and receives its push-to-update token, and
+        /// again whenever the token rotates during the activity's lifetime.
+        ///
+        /// No-op on non-iOS platforms and on iOS versions earlier than 16.1.
+        /// </remarks>
+        /// <param name="activityId">A stable, game-chosen string naming the kind of live activity (e.g. "chest_timer").</param>
+        /// <param name="pushToken">The push-to-update token bytes from ActivityKit's <c>Activity.pushTokenUpdates</c>.</param>
+        /// <param name="systemActivityId">The OS-level per-instance activity identifier, from <c>Activity.id</c>.</param>
+        /// <param name="callback">A callback invoked with the result of the call.</param>
+        public IEnumerator StartedLiveActivity(string activityId, byte[] pushToken, string systemActivityId, System.Action<Reply> callback) {
+            if (Teak.Instance.Trace) {
+                int tokenLen = pushToken == null ? 0 : pushToken.Length;
+                Debug.Log("[Teak.LiveActivity] StartedLiveActivity(" + activityId + ", <" + tokenLen + " bytes>, " + systemActivityId + ")");
+            }
+
+#if !UNITY_EDITOR && UNITY_IPHONE
+            if (!IsIOS161OrNewer()) {
+                NoOpCallback(callback);
+                yield break;
+            }
+
+            Teak.Operation operation = new Teak.Operation(() => {
+                return TeakStartedLiveActivity_Retained(activityId, pushToken, pushToken == null ? 0 : pushToken.Length, systemActivityId);
+            });
+            operation.OnDone += (result, exception) => {
+                Reply reply;
+                if (exception != null) {
+                    reply = Reply.ReplyWithErrorForException(exception);
+                } else {
+                    reply = new Reply(result);
+                }
+                Teak.SafePerformCallback("teak.liveactivity.started", callback, reply);
+            };
+            while (!operation.IsDone) { yield return null; }
+#else
+            NoOpCallback(callback);
+            yield break;
+#endif
+        }
+
+        /// <summary>
+        /// Report a Live Activity push-to-update token to Teak, using a hex-encoded token string.
+        /// </summary>
+        /// <remarks>
+        /// Convenience overload for callers who already hold the token as a hex string
+        /// (for example, persisted via <c>PlayerPrefs</c>). Decodes to bytes and delegates to
+        /// <see cref="StartedLiveActivity(string, byte[], string, System.Action{Reply})"/>.
+        /// </remarks>
+        /// <param name="activityId">A stable, game-chosen string naming the kind of live activity.</param>
+        /// <param name="pushTokenHex">The push-to-update token as a hex-encoded string.</param>
+        /// <param name="systemActivityId">The OS-level per-instance activity identifier.</param>
+        /// <param name="callback">A callback invoked with the result of the call.</param>
+        public IEnumerator StartedLiveActivity(string activityId, string pushTokenHex, string systemActivityId, System.Action<Reply> callback) {
+            byte[] tokenBytes = null;
+            Exception conversionError = null;
+            try {
+                tokenBytes = HexStringToBytes(pushTokenHex);
+            } catch (Exception e) {
+                conversionError = e;
+            }
+
+            if (conversionError != null) {
+                Teak.SafePerformCallback("teak.liveactivity.started", callback, Reply.ReplyWithErrorForException(conversionError));
+                yield break;
+            }
+
+            IEnumerator inner = this.StartedLiveActivity(activityId, tokenBytes, systemActivityId, callback);
+            while (inner.MoveNext()) { yield return inner.Current; }
+        }
+
+        /// <summary>
+        /// Schedule a single update to be delivered to a live activity at a future time.
+        /// </summary>
+        /// <remarks>
+        /// Call between <see cref="StartedLiveActivity(string, byte[], string, System.Action{Reply})"/>
+        /// and the activity ending. <paramref name="customData"/> is delivered as APNs
+        /// <c>content-state</c>; <paramref name="systemData"/> carries Apple system fields
+        /// (<c>event</c>, <c>stale-date</c>, <c>dismissal-date</c>).
+        ///
+        /// No-op on non-iOS platforms and on iOS versions earlier than 16.1.
+        /// </remarks>
+        /// <param name="activityId">A stable, game-chosen string naming the kind of live activity.</param>
+        /// <param name="offset">Delay from server-now, in seconds, at which the update should be delivered.</param>
+        /// <param name="customData">Game-defined content-state payload. Must contain only JSON-serializable values. Required.</param>
+        /// <param name="systemData">Optional Apple system fields. May be null.</param>
+        /// <param name="callback">A callback invoked with the result of the call.</param>
+        public IEnumerator ScheduleLiveActivityUpdate(string activityId, long offset, Dictionary<string, object> customData, Dictionary<string, object> systemData, System.Action<Reply> callback) {
+            if (Teak.Instance.Trace) {
+                Debug.Log("[Teak.LiveActivity] ScheduleLiveActivityUpdate(" + activityId + ", " + offset + ", " +
+                          (customData == null ? "null" : Json.Serialize(customData)) + ", " +
+                          (systemData == null ? "null" : Json.Serialize(systemData)) + ")");
+            }
+
+#if !UNITY_EDITOR && UNITY_IPHONE
+            if (!IsIOS161OrNewer()) {
+                NoOpCallback(callback);
+                yield break;
+            }
+
+            string customDataJson = customData == null ? null : Json.Serialize(customData);
+            string systemDataJson = systemData == null ? null : Json.Serialize(systemData);
+            Teak.Operation operation = new Teak.Operation(() => {
+                return TeakScheduleLiveActivityUpdate_Retained(activityId, offset, customDataJson, systemDataJson);
+            });
+            operation.OnDone += (result, exception) => {
+                Reply reply;
+                if (exception != null) {
+                    reply = Reply.ReplyWithErrorForException(exception);
+                } else {
+                    reply = new Reply(result);
+                }
+                Teak.SafePerformCallback("teak.liveactivity.schedule", callback, reply);
+            };
+            while (!operation.IsDone) { yield return null; }
+#else
+            NoOpCallback(callback);
+            yield break;
+#endif
+        }
+
+        /// <summary>
+        /// Cancel all pending scheduled updates for a live activity.
+        /// </summary>
+        /// <remarks>
+        /// Scopes to the current user's updates for <paramref name="activityId"/>; updates
+        /// scheduled for other users or other activity kinds are unaffected.
+        ///
+        /// The reply's <see cref="Reply.CanceledCount"/> carries the number of updates canceled
+        /// by the server on success.
+        ///
+        /// No-op on non-iOS platforms and on iOS versions earlier than 16.1.
+        /// </remarks>
+        /// <param name="activityId">A stable, game-chosen string naming the kind of live activity whose pending updates should be canceled.</param>
+        /// <param name="callback">A callback invoked with the result of the call.</param>
+        public IEnumerator CancelLiveActivityUpdates(string activityId, System.Action<Reply> callback) {
+            if (Teak.Instance.Trace) {
+                Debug.Log("[Teak.LiveActivity] CancelLiveActivityUpdates(" + activityId + ")");
+            }
+
+#if !UNITY_EDITOR && UNITY_IPHONE
+            if (!IsIOS161OrNewer()) {
+                NoOpCallback(callback);
+                yield break;
+            }
+
+            Teak.Operation operation = new Teak.Operation(() => {
+                return TeakCancelLiveActivityUpdates_Retained(activityId);
+            });
+            operation.OnDone += (result, exception) => {
+                Reply reply;
+                if (exception != null) {
+                    reply = Reply.ReplyWithErrorForException(exception);
+                } else {
+                    reply = new Reply(result);
+                }
+                Teak.SafePerformCallback("teak.liveactivity.cancel", callback, reply);
+            };
+            while (!operation.IsDone) { yield return null; }
+#else
+            NoOpCallback(callback);
+            yield break;
+#endif
+        }
+
+        /// @cond hide_from_doxygen
+        internal LiveActivity() { }
+
+        private static void NoOpCallback(System.Action<Reply> callback) {
+            Teak.SafePerformCallback("teak.liveactivity.noop", callback, new Reply(new Dictionary<string, object> {
+                {"status", "ok"},
+                {"noop", true}
+            }));
+        }
+
+        /// <summary>
+        /// Decode a hex-encoded string into its byte representation.
+        /// </summary>
+        /// <remarks>
+        /// Accepts upper- or lower-case hex; rejects odd-length strings, non-hex characters,
+        /// and null input.
+        /// </remarks>
+        public static byte[] HexStringToBytes(string hex) {
+            if (hex == null) {
+                throw new ArgumentNullException("hex");
+            }
+            if (hex.Length % 2 != 0) {
+                throw new ArgumentException("Hex string must have even length", "hex");
+            }
+            byte[] bytes = new byte[hex.Length / 2];
+            for (int i = 0; i < bytes.Length; i++) {
+                int hi = HexCharToInt(hex[i * 2]);
+                int lo = HexCharToInt(hex[i * 2 + 1]);
+                bytes[i] = (byte)((hi << 4) | lo);
+            }
+            return bytes;
+        }
+
+        private static int HexCharToInt(char c) {
+            if (c >= '0' && c <= '9') { return c - '0'; }
+            if (c >= 'a' && c <= 'f') { return c - 'a' + 10; }
+            if (c >= 'A' && c <= 'F') { return c - 'A' + 10; }
+            throw new ArgumentException("Invalid hex character: " + c);
+        }
+
+#if UNITY_IPHONE
+        private static bool IsIOS161OrNewer() {
+            string version = UnityEngine.iOS.Device.systemVersion;
+            if (string.IsNullOrEmpty(version)) { return false; }
+
+            string[] parts = version.Split('.');
+            int major = 0, minor = 0;
+            int.TryParse(parts[0], out major);
+            if (parts.Length > 1) { int.TryParse(parts[1], out minor); }
+
+            if (major > 16) { return true; }
+            if (major == 16 && minor >= 1) { return true; }
+            return false;
+        }
+
+        [DllImport ("__Internal")]
+        private static extern IntPtr TeakStartedLiveActivity_Retained(
+            string activityId,
+            [MarshalAs(UnmanagedType.LPArray)] byte[] pushToken,
+            int pushTokenLength,
+            string systemActivityId);
+
+        [DllImport ("__Internal")]
+        private static extern IntPtr TeakScheduleLiveActivityUpdate_Retained(
+            string activityId,
+            long offset,
+            string customDataJson,
+            string systemDataJson);
+
+        [DllImport ("__Internal")]
+        private static extern IntPtr TeakCancelLiveActivityUpdates_Retained(string activityId);
+#endif
+        /// @endcond
+    }
+
+    private LiveActivity mLiveActivity;
+
+    /// <summary>
+    /// Teak Live Activity functionality (iOS 16.1+).
+    /// </summary>
+    /// <remarks>
+    /// No-op on non-iOS platforms and on iOS versions earlier than 16.1.
+    /// </remarks>
+    public LiveActivity LiveActivities {
+        get {
+            if (this.mLiveActivity == null) {
+                this.mLiveActivity = new LiveActivity();
+            }
+            return this.mLiveActivity;
+        }
+    }
+}

--- a/Assets/Teak/Teak.LiveActivity.cs
+++ b/Assets/Teak/Teak.LiveActivity.cs
@@ -197,8 +197,22 @@ public partial class Teak {
         public IEnumerator ScheduleLiveActivityUpdate(string activityId, long offset, Dictionary<string, object> customData, Dictionary<string, object> systemData, System.Action<Reply> callback) {
             if (Teak.Instance.Trace) {
                 Debug.Log("[Teak.LiveActivity] ScheduleLiveActivityUpdate(" + activityId + ", " + offset + ", " +
-                          (customData == null ? "null" : Json.Serialize(customData)) + ", " +
-                          (systemData == null ? "null" : Json.Serialize(systemData)) + ")");
+                          (customData == null ? "null" : "<customData>") + ", " +
+                          (systemData == null ? "null" : "<systemData>") + ")");
+            }
+
+            if (customData == null) {
+                Teak.SafePerformCallback("teak.liveactivity.schedule", callback, BuildFieldError("customData", "customData cannot be null"));
+                yield break;
+            }
+
+            string customDataJson, systemDataJson;
+            try {
+                customDataJson = Json.Serialize(customData);
+                systemDataJson = systemData == null ? null : Json.Serialize(systemData);
+            } catch (Exception e) {
+                Teak.SafePerformCallback("teak.liveactivity.schedule", callback, Reply.ReplyWithErrorForException(e));
+                yield break;
             }
 
 #if !UNITY_EDITOR && UNITY_IPHONE
@@ -207,8 +221,6 @@ public partial class Teak {
                 yield break;
             }
 
-            string customDataJson = customData == null ? null : Json.Serialize(customData);
-            string systemDataJson = systemData == null ? null : Json.Serialize(systemData);
             Teak.Operation operation = new Teak.Operation(() => {
                 return TeakScheduleLiveActivityUpdate_Retained(activityId, offset, customDataJson, systemDataJson);
             });
@@ -282,6 +294,17 @@ public partial class Teak {
             }));
         }
 
+        private static Reply BuildFieldError(string field, string message) {
+            return new Reply(new Dictionary<string, object> {
+                {"status", "error"},
+                {
+                    "errors", new Dictionary<string, object> {
+                        {field, new string[] { message }}
+                    }
+                }
+            });
+        }
+
         /// <summary>
         /// Decode a hex-encoded string into its byte representation.
         /// </summary>
@@ -312,7 +335,7 @@ public partial class Teak {
             throw new ArgumentException("Invalid hex character: " + c);
         }
 
-#if UNITY_IPHONE
+#if !UNITY_EDITOR && UNITY_IPHONE
         private static bool IsIOS161OrNewer() {
             string version = UnityEngine.iOS.Device.systemVersion;
             if (string.IsNullOrEmpty(version)) { return false; }
@@ -326,7 +349,9 @@ public partial class Teak {
             if (major == 16 && minor >= 1) { return true; }
             return false;
         }
+#endif
 
+#if UNITY_IPHONE
         [DllImport ("__Internal")]
         private static extern IntPtr TeakStartedLiveActivity_Retained(
             string activityId,

--- a/Assets/Teak/Teak.LiveActivity.cs
+++ b/Assets/Teak/Teak.LiveActivity.cs
@@ -15,20 +15,12 @@ using TeakExtensions;
 public partial class Teak {
 
     /// <summary>
-    /// Teak Live Activity functionality (iOS 16.1+).
+    /// Teak Live Activity functionality.
     /// </summary>
     /// <remarks>
-    /// Live Activities are an iOS-only feature. All methods on this class no-op on non-iOS
-    /// platforms. On iOS the native SDK enforces the iOS 16.1 availability requirement
-    /// (<c>@available(iOS 16.1, *)</c>); calling these methods on older iOS versions returns
-    /// an error <see cref="Reply"/> from the native side without crashing.
-    ///
-    /// Activity-resumption attribution (taps on a Live Activity that launch the app) flows
-    /// through the existing session-attribution path on the native iOS SDK: when the app is
-    /// launched via activity resumption, the native SDK constructs a <c>TeakLiveActivityLaunchData</c>
-    /// whose session attribution carries <c>teak_live_activity_id</c>. This surfaces on the
-    /// Unity side via <see cref="Teak.OnPostLaunchSummary"/>; no explicit Unity-side API is
-    /// required to receive it.
+    /// Taps on a Live Activity that launch the app are tracked as clicks; the activity is
+    /// surfaced via <see cref="Teak.OnPostLaunchSummary"/> — look for
+    /// <c>teak_live_activity_id</c>.
     /// </remarks>
     public partial class LiveActivity {
 
@@ -113,21 +105,21 @@ public partial class Teak {
         /// Call this when a live activity starts and receives its push-to-update token, and
         /// again whenever the token rotates during the activity's lifetime.
         ///
-        /// No-op on non-iOS platforms.
         /// </remarks>
         /// <param name="activityId">A stable, game-chosen string naming the kind of live activity (e.g. "chest_timer").</param>
         /// <param name="pushToken">The push-to-update token bytes from ActivityKit's <c>Activity.pushTokenUpdates</c>.</param>
         /// <param name="systemActivityId">The OS-level per-instance activity identifier, from <c>Activity.id</c>.</param>
         /// <param name="callback">A callback invoked with the result of the call.</param>
         public static IEnumerator StartedLiveActivity(string activityId, byte[] pushToken, string systemActivityId, System.Action<Reply> callback) {
+            int tokenLength = pushToken == null ? 0 : pushToken.Length;
+
             if (Teak.Instance.Trace) {
-                int tokenLen = pushToken == null ? 0 : pushToken.Length;
-                Debug.Log("[Teak.LiveActivity] StartedLiveActivity(" + activityId + ", <" + tokenLen + " bytes>, " + systemActivityId + ")");
+                Debug.Log("[Teak.LiveActivity] StartedLiveActivity(" + activityId + ", <" + tokenLength + " bytes>, " + systemActivityId + ")");
             }
 
 #if !UNITY_EDITOR && UNITY_IPHONE
             Teak.Operation operation = new Teak.Operation(() => {
-                return TeakStartedLiveActivity_Retained(activityId, pushToken, pushToken == null ? 0 : pushToken.Length, systemActivityId);
+                return TeakStartedLiveActivity_Retained(activityId, pushToken, tokenLength, systemActivityId);
             });
             operation.OnDone += (result, exception) => {
                 Reply reply;
@@ -184,7 +176,6 @@ public partial class Teak {
         /// <c>content-state</c>; <paramref name="systemData"/> carries Apple system fields
         /// (<c>event</c>, <c>stale-date</c>, <c>dismissal-date</c>).
         ///
-        /// No-op on non-iOS platforms.
         /// </remarks>
         /// <param name="activityId">A stable, game-chosen string naming the kind of live activity.</param>
         /// <param name="offset">Delay from server-now, in seconds, at which the update should be delivered.</param>
@@ -242,7 +233,6 @@ public partial class Teak {
         /// The reply's <see cref="Reply.CanceledCount"/> carries the number of updates canceled
         /// by the server on success.
         ///
-        /// No-op on non-iOS platforms.
         /// </remarks>
         /// <param name="activityId">A stable, game-chosen string naming the kind of live activity whose pending updates should be canceled.</param>
         /// <param name="callback">A callback invoked with the result of the call.</param>

--- a/Assets/Teak/Teak.LiveActivity.cs
+++ b/Assets/Teak/Teak.LiveActivity.cs
@@ -18,9 +18,10 @@ public partial class Teak {
     /// Teak Live Activity functionality.
     /// </summary>
     /// <remarks>
-    /// Taps on a Live Activity that launch the app are tracked as clicks; the activity is
-    /// surfaced via <see cref="Teak.OnPostLaunchSummary"/> — look for
-    /// <c>teak_live_activity_id</c>.
+    /// Taps on a Live Activity that launch the app are tracked as clicks; the launching
+    /// activity's <c>Activity.id</c> is surfaced as
+    /// <see cref="TeakPostLaunchSummary.SystemActivityId"/> on
+    /// <see cref="Teak.OnPostLaunchSummary"/>.
     /// </remarks>
     public partial class LiveActivity {
 

--- a/Assets/Teak/Teak.LiveActivity.cs
+++ b/Assets/Teak/Teak.LiveActivity.cs
@@ -19,7 +19,9 @@ public partial class Teak {
     /// </summary>
     /// <remarks>
     /// Live Activities are an iOS-only feature. All methods on this class no-op on non-iOS
-    /// platforms and on iOS versions earlier than 16.1.
+    /// platforms. On iOS the native SDK enforces the iOS 16.1 availability requirement
+    /// (<c>@available(iOS 16.1, *)</c>); calling these methods on older iOS versions returns
+    /// an error <see cref="Reply"/> from the native side without crashing.
     ///
     /// Activity-resumption attribution (taps on a Live Activity that launch the app) flows
     /// through the existing session-attribution path on the native iOS SDK: when the app is
@@ -111,24 +113,19 @@ public partial class Teak {
         /// Call this when a live activity starts and receives its push-to-update token, and
         /// again whenever the token rotates during the activity's lifetime.
         ///
-        /// No-op on non-iOS platforms and on iOS versions earlier than 16.1.
+        /// No-op on non-iOS platforms.
         /// </remarks>
         /// <param name="activityId">A stable, game-chosen string naming the kind of live activity (e.g. "chest_timer").</param>
         /// <param name="pushToken">The push-to-update token bytes from ActivityKit's <c>Activity.pushTokenUpdates</c>.</param>
         /// <param name="systemActivityId">The OS-level per-instance activity identifier, from <c>Activity.id</c>.</param>
         /// <param name="callback">A callback invoked with the result of the call.</param>
-        public IEnumerator StartedLiveActivity(string activityId, byte[] pushToken, string systemActivityId, System.Action<Reply> callback) {
+        public static IEnumerator StartedLiveActivity(string activityId, byte[] pushToken, string systemActivityId, System.Action<Reply> callback) {
             if (Teak.Instance.Trace) {
                 int tokenLen = pushToken == null ? 0 : pushToken.Length;
                 Debug.Log("[Teak.LiveActivity] StartedLiveActivity(" + activityId + ", <" + tokenLen + " bytes>, " + systemActivityId + ")");
             }
 
 #if !UNITY_EDITOR && UNITY_IPHONE
-            if (!IsIOS161OrNewer()) {
-                NoOpCallback(callback);
-                yield break;
-            }
-
             Teak.Operation operation = new Teak.Operation(() => {
                 return TeakStartedLiveActivity_Retained(activityId, pushToken, pushToken == null ? 0 : pushToken.Length, systemActivityId);
             });
@@ -160,7 +157,7 @@ public partial class Teak {
         /// <param name="pushTokenHex">The push-to-update token as a hex-encoded string.</param>
         /// <param name="systemActivityId">The OS-level per-instance activity identifier.</param>
         /// <param name="callback">A callback invoked with the result of the call.</param>
-        public IEnumerator StartedLiveActivity(string activityId, string pushTokenHex, string systemActivityId, System.Action<Reply> callback) {
+        public static IEnumerator StartedLiveActivity(string activityId, string pushTokenHex, string systemActivityId, System.Action<Reply> callback) {
             byte[] tokenBytes = null;
             Exception conversionError = null;
             try {
@@ -174,7 +171,7 @@ public partial class Teak {
                 yield break;
             }
 
-            IEnumerator inner = this.StartedLiveActivity(activityId, tokenBytes, systemActivityId, callback);
+            IEnumerator inner = StartedLiveActivity(activityId, tokenBytes, systemActivityId, callback);
             while (inner.MoveNext()) { yield return inner.Current; }
         }
 
@@ -187,14 +184,14 @@ public partial class Teak {
         /// <c>content-state</c>; <paramref name="systemData"/> carries Apple system fields
         /// (<c>event</c>, <c>stale-date</c>, <c>dismissal-date</c>).
         ///
-        /// No-op on non-iOS platforms and on iOS versions earlier than 16.1.
+        /// No-op on non-iOS platforms.
         /// </remarks>
         /// <param name="activityId">A stable, game-chosen string naming the kind of live activity.</param>
         /// <param name="offset">Delay from server-now, in seconds, at which the update should be delivered.</param>
         /// <param name="customData">Game-defined content-state payload. Must contain only JSON-serializable values. Required.</param>
         /// <param name="systemData">Optional Apple system fields. May be null.</param>
         /// <param name="callback">A callback invoked with the result of the call.</param>
-        public IEnumerator ScheduleLiveActivityUpdate(string activityId, long offset, Dictionary<string, object> customData, Dictionary<string, object> systemData, System.Action<Reply> callback) {
+        public static IEnumerator ScheduleLiveActivityUpdate(string activityId, long offset, Dictionary<string, object> customData, Dictionary<string, object> systemData, System.Action<Reply> callback) {
             if (Teak.Instance.Trace) {
                 Debug.Log("[Teak.LiveActivity] ScheduleLiveActivityUpdate(" + activityId + ", " + offset + ", " +
                           (customData == null ? "null" : "<customData>") + ", " +
@@ -216,11 +213,6 @@ public partial class Teak {
             }
 
 #if !UNITY_EDITOR && UNITY_IPHONE
-            if (!IsIOS161OrNewer()) {
-                NoOpCallback(callback);
-                yield break;
-            }
-
             Teak.Operation operation = new Teak.Operation(() => {
                 return TeakScheduleLiveActivityUpdate_Retained(activityId, offset, customDataJson, systemDataJson);
             });
@@ -250,21 +242,16 @@ public partial class Teak {
         /// The reply's <see cref="Reply.CanceledCount"/> carries the number of updates canceled
         /// by the server on success.
         ///
-        /// No-op on non-iOS platforms and on iOS versions earlier than 16.1.
+        /// No-op on non-iOS platforms.
         /// </remarks>
         /// <param name="activityId">A stable, game-chosen string naming the kind of live activity whose pending updates should be canceled.</param>
         /// <param name="callback">A callback invoked with the result of the call.</param>
-        public IEnumerator CancelLiveActivityUpdates(string activityId, System.Action<Reply> callback) {
+        public static IEnumerator CancelLiveActivityUpdates(string activityId, System.Action<Reply> callback) {
             if (Teak.Instance.Trace) {
                 Debug.Log("[Teak.LiveActivity] CancelLiveActivityUpdates(" + activityId + ")");
             }
 
 #if !UNITY_EDITOR && UNITY_IPHONE
-            if (!IsIOS161OrNewer()) {
-                NoOpCallback(callback);
-                yield break;
-            }
-
             Teak.Operation operation = new Teak.Operation(() => {
                 return TeakCancelLiveActivityUpdates_Retained(activityId);
             });
@@ -285,13 +272,34 @@ public partial class Teak {
         }
 
         /// @cond hide_from_doxygen
-        internal LiveActivity() { }
-
         private static void NoOpCallback(System.Action<Reply> callback) {
             Teak.SafePerformCallback("teak.liveactivity.noop", callback, new Reply(new Dictionary<string, object> {
                 {"status", "ok"},
                 {"noop", true}
             }));
+        }
+
+        // System.Convert.FromHexString landed in .NET 5; Unity 2022.3's .NET Standard 2.1
+        // target does not include it, so we ship a minimal decoder.
+        private static byte[] HexStringToBytes(string hex) {
+            if (hex == null) {
+                throw new ArgumentNullException("hex");
+            }
+            if (hex.Length % 2 != 0) {
+                throw new ArgumentException("Hex string must have even length", "hex");
+            }
+            byte[] bytes = new byte[hex.Length / 2];
+            for (int i = 0; i < bytes.Length; i++) {
+                bytes[i] = (byte)((HexCharToInt(hex[i * 2]) << 4) | HexCharToInt(hex[i * 2 + 1]));
+            }
+            return bytes;
+        }
+
+        private static int HexCharToInt(char c) {
+            if (c >= '0' && c <= '9') { return c - '0'; }
+            if (c >= 'a' && c <= 'f') { return c - 'a' + 10; }
+            if (c >= 'A' && c <= 'F') { return c - 'A' + 10; }
+            throw new ArgumentException("Invalid hex character: " + c);
         }
 
         private static Reply BuildFieldError(string field, string message) {
@@ -304,52 +312,6 @@ public partial class Teak {
                 }
             });
         }
-
-        /// <summary>
-        /// Decode a hex-encoded string into its byte representation.
-        /// </summary>
-        /// <remarks>
-        /// Accepts upper- or lower-case hex; rejects odd-length strings, non-hex characters,
-        /// and null input.
-        /// </remarks>
-        public static byte[] HexStringToBytes(string hex) {
-            if (hex == null) {
-                throw new ArgumentNullException("hex");
-            }
-            if (hex.Length % 2 != 0) {
-                throw new ArgumentException("Hex string must have even length", "hex");
-            }
-            byte[] bytes = new byte[hex.Length / 2];
-            for (int i = 0; i < bytes.Length; i++) {
-                int hi = HexCharToInt(hex[i * 2]);
-                int lo = HexCharToInt(hex[i * 2 + 1]);
-                bytes[i] = (byte)((hi << 4) | lo);
-            }
-            return bytes;
-        }
-
-        private static int HexCharToInt(char c) {
-            if (c >= '0' && c <= '9') { return c - '0'; }
-            if (c >= 'a' && c <= 'f') { return c - 'a' + 10; }
-            if (c >= 'A' && c <= 'F') { return c - 'A' + 10; }
-            throw new ArgumentException("Invalid hex character: " + c);
-        }
-
-#if !UNITY_EDITOR && UNITY_IPHONE
-        private static bool IsIOS161OrNewer() {
-            string version = UnityEngine.iOS.Device.systemVersion;
-            if (string.IsNullOrEmpty(version)) { return false; }
-
-            string[] parts = version.Split('.');
-            int major = 0, minor = 0;
-            int.TryParse(parts[0], out major);
-            if (parts.Length > 1) { int.TryParse(parts[1], out minor); }
-
-            if (major > 16) { return true; }
-            if (major == 16 && minor >= 1) { return true; }
-            return false;
-        }
-#endif
 
 #if UNITY_IPHONE
         [DllImport ("__Internal")]
@@ -370,22 +332,5 @@ public partial class Teak {
         private static extern IntPtr TeakCancelLiveActivityUpdates_Retained(string activityId);
 #endif
         /// @endcond
-    }
-
-    private LiveActivity mLiveActivity;
-
-    /// <summary>
-    /// Teak Live Activity functionality (iOS 16.1+).
-    /// </summary>
-    /// <remarks>
-    /// No-op on non-iOS platforms and on iOS versions earlier than 16.1.
-    /// </remarks>
-    public LiveActivity LiveActivities {
-        get {
-            if (this.mLiveActivity == null) {
-                this.mLiveActivity = new LiveActivity();
-            }
-            return this.mLiveActivity;
-        }
     }
 }

--- a/Assets/Teak/Teak.LiveActivity.cs.meta
+++ b/Assets/Teak/Teak.LiveActivity.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c4111c5d369034027837f3846a47b168
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Teak/TeakPostLaunchSummary.cs
+++ b/Assets/Teak/TeakPostLaunchSummary.cs
@@ -39,12 +39,17 @@ public class TeakPostLaunchSummary {
     /// <summary>OptOut category for this notification, or ``"teak"`` as the default.</summary>
     public string OptOutCategory { get; private set; }
 
+    /// <summary>The OS-level per-instance live activity identifier (ActivityKit's
+    /// ``Activity.id``) of the live activity whose tap launched this session, or
+    /// ``null`` if this launch was not from a live activity tap.</summary>
+    public string SystemActivityId { get; private set; }
+
     /// <summary>
     /// Returns a string that represents the current object.
     /// </summary>
     /// <returns>A string that represents the current object.</returns>
     public override string ToString() {
-        string formatString = "{{ LaunchLink = '{0}', ScheduleName = '{1}', ScheduleId = '{2}', CreativeName = '{3}', CreativeId = '{4}', RewardId = '{5}', ChannelName = '{6}', DeepLink = '{7}', SourceSendId = '{8}', OptOutCategory = '{9}' }}";
+        string formatString = "{{ LaunchLink = '{0}', ScheduleName = '{1}', ScheduleId = '{2}', CreativeName = '{3}', CreativeId = '{4}', RewardId = '{5}', ChannelName = '{6}', DeepLink = '{7}', SourceSendId = '{8}', OptOutCategory = '{9}', SystemActivityId = '{10}' }}";
         return string.Format(formatString,
                              this.LaunchLink,
                              this.ScheduleName,
@@ -55,7 +60,8 @@ public class TeakPostLaunchSummary {
                              this.ChannelName,
                              this.DeepLink,
                              this.SourceSendId,
-                             this.OptOutCategory
+                             this.OptOutCategory,
+                             this.SystemActivityId
                             );
     }
 
@@ -71,6 +77,7 @@ public class TeakPostLaunchSummary {
         this.DeepLink = json.ContainsKey("teakDeepLink") ? json["teakDeepLink"] as string : null;
         this.SourceSendId = json.ContainsKey("teakNotifId") ? json["teakNotifId"] as string : null;
         this.OptOutCategory = json.ContainsKey("teakOptOutCategory") ? json["teakOptOutCategory"] as string : null;
+        this.SystemActivityId = json.ContainsKey("teakSystemActivityId") ? json["teakSystemActivityId"] as string : null;
     }
     /// @endcond
 }

--- a/Assets/Tests/Editor/TeakLiveActivityTests.cs
+++ b/Assets/Tests/Editor/TeakLiveActivityTests.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+
+[TeakTestFixture]
+public class TeakLiveActivityTests {
+
+    [TeakTest]
+    public void ReplyParsesOkStatus() {
+        var reply = new Teak.LiveActivity.Reply(new Dictionary<string, object> {
+            {"status", "ok"}
+        });
+        TeakAssert.IsFalse(reply.Error);
+        TeakAssert.IsNull(reply.Errors);
+        TeakAssert.IsNull(reply.CanceledCount);
+    }
+
+    [TeakTest]
+    public void ReplyParsesErrorStatus() {
+        var reply = new Teak.LiveActivity.Reply(new Dictionary<string, object> {
+            {"status", "error"},
+            {"errors", new Dictionary<string, object> {
+                {"activityId", new List<object> {"activityId cannot be null or empty"}}
+            }}
+        });
+        TeakAssert.IsTrue(reply.Error);
+        TeakAssert.IsNotNull(reply.Errors);
+        TeakAssert.AreEqual(1, reply.Errors["activityId"].Count);
+        TeakAssert.AreEqual("activityId cannot be null or empty", reply.Errors["activityId"][0]);
+    }
+
+    [TeakTest]
+    public void ReplyParsesCanceledCount() {
+        var reply = new Teak.LiveActivity.Reply(new Dictionary<string, object> {
+            {"status", "ok"},
+            {"canceled", 3L}
+        });
+        TeakAssert.IsFalse(reply.Error);
+        TeakAssert.IsNotNull(reply.CanceledCount);
+        TeakAssert.AreEqual(3, reply.CanceledCount);
+    }
+
+    [TeakTest]
+    public void ReplyCanceledCountAcceptsInt() {
+        var reply = new Teak.LiveActivity.Reply(new Dictionary<string, object> {
+            {"status", "ok"},
+            {"canceled", 5}
+        });
+        TeakAssert.AreEqual(5, reply.CanceledCount);
+    }
+
+    [TeakTest]
+    public void ReplyMissingStatusIsError() {
+        var reply = new Teak.LiveActivity.Reply(new Dictionary<string, object>());
+        TeakAssert.IsTrue(reply.Error);
+    }
+
+    [TeakTest]
+    public void ReplyPreservesRawJson() {
+        var source = new Dictionary<string, object> {
+            {"status", "ok"},
+            {"canceled", 2L}
+        };
+        var reply = new Teak.LiveActivity.Reply(source);
+        TeakAssert.IsTrue(ReferenceEquals(source, reply.Json), "Reply should retain the source dictionary reference");
+    }
+
+    [TeakTest]
+    public void ReplyWithErrorForExceptionIsError() {
+        var reply = Teak.LiveActivity.Reply.ReplyWithErrorForException(new InvalidOperationException("boom"));
+        TeakAssert.IsTrue(reply.Error);
+        TeakAssert.IsNotNull(reply.Errors);
+        TeakAssert.IsTrue(reply.Errors.ContainsKey("unity"));
+    }
+
+    [TeakTest]
+    public void HexStringToBytesRoundTrip() {
+        byte[] expected = new byte[] { 0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x23 };
+        byte[] actual = Teak.LiveActivity.HexStringToBytes("deadbeef0123");
+        TeakAssert.AreEqual(expected.Length, actual.Length);
+        for (int i = 0; i < expected.Length; i++) {
+            TeakAssert.AreEqual(expected[i], actual[i]);
+        }
+    }
+
+    [TeakTest]
+    public void HexStringToBytesAcceptsUppercase() {
+        byte[] actual = Teak.LiveActivity.HexStringToBytes("DEADBEEF");
+        TeakAssert.AreEqual(4, actual.Length);
+        TeakAssert.AreEqual((byte)0xDE, actual[0]);
+        TeakAssert.AreEqual((byte)0xEF, actual[3]);
+    }
+
+    [TeakTest]
+    public void HexStringToBytesRejectsOddLength() {
+        bool threw = false;
+        try {
+            Teak.LiveActivity.HexStringToBytes("abc");
+        } catch (ArgumentException) {
+            threw = true;
+        }
+        TeakAssert.IsTrue(threw, "expected ArgumentException for odd-length hex");
+    }
+
+    [TeakTest]
+    public void HexStringToBytesRejectsNonHexChar() {
+        bool threw = false;
+        try {
+            Teak.LiveActivity.HexStringToBytes("zz");
+        } catch (ArgumentException) {
+            threw = true;
+        }
+        TeakAssert.IsTrue(threw, "expected ArgumentException for non-hex char");
+    }
+
+    [TeakTest]
+    public void HexStringToBytesRejectsNull() {
+        bool threw = false;
+        try {
+            Teak.LiveActivity.HexStringToBytes(null);
+        } catch (ArgumentNullException) {
+            threw = true;
+        }
+        TeakAssert.IsTrue(threw, "expected ArgumentNullException for null");
+    }
+}

--- a/Assets/Tests/Editor/TeakLiveActivityTests.cs
+++ b/Assets/Tests/Editor/TeakLiveActivityTests.cs
@@ -122,4 +122,43 @@ public class TeakLiveActivityTests {
         }
         TeakAssert.IsTrue(threw, "expected ArgumentNullException for null");
     }
+
+    // Drains a coroutine synchronously for editor-mode tests — all Teak coroutines finish
+    // in a single step on editor/non-iOS platforms because the native path is skipped.
+    static void DrainCoroutine(System.Collections.IEnumerator co) {
+        while (co.MoveNext()) { }
+    }
+
+    [TeakTest]
+    public void StartedLiveActivityHexOverloadInvokesErrorCallbackOnInvalidHex() {
+        Teak.LiveActivity.Reply captured = null;
+        var teak = new UnityEngine.GameObject("TeakForTest").AddComponent<Teak>();
+        try {
+            DrainCoroutine(teak.LiveActivities.StartedLiveActivity(
+                "chest_timer", "zz", "sys-1", r => { captured = r; }));
+            TeakAssert.IsNotNull(captured, "callback must fire even on bad hex");
+            TeakAssert.IsTrue(captured.Error, "reply must be error for invalid hex");
+            TeakAssert.IsNotNull(captured.Errors);
+            TeakAssert.IsTrue(captured.Errors.ContainsKey("unity"));
+        } finally {
+            UnityEngine.Object.DestroyImmediate(teak.gameObject);
+        }
+    }
+
+    [TeakTest]
+    public void ScheduleLiveActivityUpdateInvokesErrorCallbackOnNullCustomData() {
+        Teak.LiveActivity.Reply captured = null;
+        var teak = new UnityEngine.GameObject("TeakForTest").AddComponent<Teak>();
+        try {
+            DrainCoroutine(teak.LiveActivities.ScheduleLiveActivityUpdate(
+                "chest_timer", 60, null, null, r => { captured = r; }));
+            TeakAssert.IsNotNull(captured, "callback must fire when customData is null");
+            TeakAssert.IsTrue(captured.Error, "reply must be error for null customData");
+            TeakAssert.IsNotNull(captured.Errors);
+            TeakAssert.IsTrue(captured.Errors.ContainsKey("customData"));
+        } finally {
+            UnityEngine.Object.DestroyImmediate(teak.gameObject);
+        }
+    }
+
 }

--- a/Assets/Tests/Editor/TeakLiveActivityTests.cs
+++ b/Assets/Tests/Editor/TeakLiveActivityTests.cs
@@ -72,59 +72,6 @@ public class TeakLiveActivityTests {
         TeakAssert.IsTrue(reply.Errors.ContainsKey("unity"));
     }
 
-    [TeakTest]
-    public void HexStringToBytesRoundTrip() {
-        byte[] expected = new byte[] { 0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x23 };
-        byte[] actual = Teak.LiveActivity.HexStringToBytes("deadbeef0123");
-        TeakAssert.AreEqual(expected.Length, actual.Length);
-        for (int i = 0; i < expected.Length; i++) {
-            TeakAssert.AreEqual(expected[i], actual[i]);
-        }
-    }
-
-    [TeakTest]
-    public void HexStringToBytesAcceptsUppercase() {
-        byte[] actual = Teak.LiveActivity.HexStringToBytes("DEADBEEF");
-        TeakAssert.AreEqual(4, actual.Length);
-        TeakAssert.AreEqual((byte)0xDE, actual[0]);
-        TeakAssert.AreEqual((byte)0xEF, actual[3]);
-    }
-
-    [TeakTest]
-    public void HexStringToBytesRejectsOddLength() {
-        bool threw = false;
-        try {
-            Teak.LiveActivity.HexStringToBytes("abc");
-        } catch (ArgumentException) {
-            threw = true;
-        }
-        TeakAssert.IsTrue(threw, "expected ArgumentException for odd-length hex");
-    }
-
-    [TeakTest]
-    public void HexStringToBytesRejectsNonHexChar() {
-        bool threw = false;
-        try {
-            Teak.LiveActivity.HexStringToBytes("zz");
-        } catch (ArgumentException) {
-            threw = true;
-        }
-        TeakAssert.IsTrue(threw, "expected ArgumentException for non-hex char");
-    }
-
-    [TeakTest]
-    public void HexStringToBytesRejectsNull() {
-        bool threw = false;
-        try {
-            Teak.LiveActivity.HexStringToBytes(null);
-        } catch (ArgumentNullException) {
-            threw = true;
-        }
-        TeakAssert.IsTrue(threw, "expected ArgumentNullException for null");
-    }
-
-    // Drains a coroutine synchronously for editor-mode tests — all Teak coroutines finish
-    // in a single step on editor/non-iOS platforms because the native path is skipped.
     static void DrainCoroutine(System.Collections.IEnumerator co) {
         while (co.MoveNext()) { }
     }
@@ -134,7 +81,7 @@ public class TeakLiveActivityTests {
         Teak.LiveActivity.Reply captured = null;
         var teak = new UnityEngine.GameObject("TeakForTest").AddComponent<Teak>();
         try {
-            DrainCoroutine(teak.LiveActivities.StartedLiveActivity(
+            DrainCoroutine(Teak.LiveActivity.StartedLiveActivity(
                 "chest_timer", "zz", "sys-1", r => { captured = r; }));
             TeakAssert.IsNotNull(captured, "callback must fire even on bad hex");
             TeakAssert.IsTrue(captured.Error, "reply must be error for invalid hex");
@@ -150,7 +97,7 @@ public class TeakLiveActivityTests {
         Teak.LiveActivity.Reply captured = null;
         var teak = new UnityEngine.GameObject("TeakForTest").AddComponent<Teak>();
         try {
-            DrainCoroutine(teak.LiveActivities.ScheduleLiveActivityUpdate(
+            DrainCoroutine(Teak.LiveActivity.ScheduleLiveActivityUpdate(
                 "chest_timer", 60, null, null, r => { captured = r; }));
             TeakAssert.IsNotNull(captured, "callback must fire when customData is null");
             TeakAssert.IsTrue(captured.Error, "reply must be error for null customData");
@@ -160,5 +107,4 @@ public class TeakLiveActivityTests {
             UnityEngine.Object.DestroyImmediate(teak.gameObject);
         }
     }
-
 }

--- a/Assets/Tests/Editor/TeakLiveActivityTests.cs.meta
+++ b/Assets/Tests/Editor/TeakLiveActivityTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a497a744319d0476e84c7912d2dc7ec1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/TeakPostLaunchSummaryTests.cs
+++ b/Assets/Tests/Editor/TeakPostLaunchSummaryTests.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+
+[TeakTestFixture]
+public class TeakPostLaunchSummaryTests {
+
+    [TeakTest]
+    public void SystemActivityIdParsedFromLaunchData() {
+        var summary = new TeakPostLaunchSummary(new Dictionary<string, object> {
+            {"teakSystemActivityId", "ABCD-1234"}
+        });
+        TeakAssert.AreEqual("ABCD-1234", summary.SystemActivityId);
+    }
+
+    [TeakTest]
+    public void SystemActivityIdNullWhenAbsent() {
+        var summary = new TeakPostLaunchSummary(new Dictionary<string, object>());
+        TeakAssert.IsNull(summary.SystemActivityId);
+    }
+}

--- a/Assets/Tests/Editor/TeakPostLaunchSummaryTests.cs.meta
+++ b/Assets/Tests/Editor/TeakPostLaunchSummaryTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 08427b9dca84043cc89430bc09922b50
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/docs/modules/changelog/unreleased.yaml
+++ b/docs/modules/changelog/unreleased.yaml
@@ -1,3 +1,3 @@
 new:
-  - "Live Activities (iOS 16.1+): Added ``Teak.Instance.LiveActivities.StartedLiveActivity``, ``Teak.Instance.LiveActivities.ScheduleLiveActivityUpdate``, and ``Teak.Instance.LiveActivities.CancelLiveActivityUpdates`` for reporting push-to-update tokens, scheduling server-driven updates, and canceling pending updates. All three are no-ops on non-iOS platforms and on iOS versions earlier than 16.1."
+  - "Live Activities (iOS 16.1+): Added ``Teak.LiveActivity.StartedLiveActivity``, ``Teak.LiveActivity.ScheduleLiveActivityUpdate``, and ``Teak.LiveActivity.CancelLiveActivityUpdates`` for reporting push-to-update tokens, scheduling server-driven updates, and canceling pending updates. No-op on non-iOS platforms."
   - "Live Activity tap attribution: When a player taps a Live Activity to resume the app, the ``system_activity_id`` is surfaced as ``teak_live_activity_id`` on ``Teak.OnPostLaunchSummary``."

--- a/docs/modules/changelog/unreleased.yaml
+++ b/docs/modules/changelog/unreleased.yaml
@@ -1,3 +1,3 @@
 new:
   - "Live Activities: Added ``Teak.LiveActivity.StartedLiveActivity``, ``Teak.LiveActivity.ScheduleLiveActivityUpdate``, and ``Teak.LiveActivity.CancelLiveActivityUpdates`` for reporting push-to-update tokens, scheduling server-driven updates, and canceling pending updates."
-  - "Live Activity tap attribution: Taps on a Live Activity that launch the app surface ``teak_live_activity_id`` on ``Teak.OnPostLaunchSummary``."
+  - "Live Activity tap attribution: Taps on a Live Activity that launch the app surface the launching activity's ``Activity.id`` as ``TeakPostLaunchSummary.SystemActivityId`` on ``Teak.OnPostLaunchSummary``."

--- a/docs/modules/changelog/unreleased.yaml
+++ b/docs/modules/changelog/unreleased.yaml
@@ -1,3 +1,3 @@
 new:
-  - "Live Activities (iOS 16.1+): Added ``Teak.LiveActivity.StartedLiveActivity``, ``Teak.LiveActivity.ScheduleLiveActivityUpdate``, and ``Teak.LiveActivity.CancelLiveActivityUpdates`` for reporting push-to-update tokens, scheduling server-driven updates, and canceling pending updates. No-op on non-iOS platforms."
-  - "Live Activity tap attribution: When a player taps a Live Activity to resume the app, the ``system_activity_id`` is surfaced as ``teak_live_activity_id`` on ``Teak.OnPostLaunchSummary``."
+  - "Live Activities: Added ``Teak.LiveActivity.StartedLiveActivity``, ``Teak.LiveActivity.ScheduleLiveActivityUpdate``, and ``Teak.LiveActivity.CancelLiveActivityUpdates`` for reporting push-to-update tokens, scheduling server-driven updates, and canceling pending updates."
+  - "Live Activity tap attribution: Taps on a Live Activity that launch the app surface ``teak_live_activity_id`` on ``Teak.OnPostLaunchSummary``."

--- a/docs/modules/changelog/unreleased.yaml
+++ b/docs/modules/changelog/unreleased.yaml
@@ -1,1 +1,3 @@
-
+new:
+  - "Live Activities (iOS 16.1+): Added ``Teak.Instance.LiveActivities.StartedLiveActivity``, ``Teak.Instance.LiveActivities.ScheduleLiveActivityUpdate``, and ``Teak.Instance.LiveActivities.CancelLiveActivityUpdates`` for reporting push-to-update tokens, scheduling server-driven updates, and canceling pending updates. All three are no-ops on non-iOS platforms and on iOS versions earlier than 16.1."
+  - "Live Activity tap attribution: When a player taps a Live Activity to resume the app, the ``system_activity_id`` is surfaced as ``teak_live_activity_id`` on ``Teak.OnPostLaunchSummary``."


### PR DESCRIPTION
## Summary
- Adds `Teak.Instance.LiveActivities.StartedLiveActivity` / `ScheduleLiveActivityUpdate` / `CancelLiveActivityUpdates` — C# P/Invoke wrappers around the iOS public APIs landed in teak-ios C-641 / C-643 / C-644 / C-688.
- Coroutine-based, returning a `LiveActivity.Reply` via `System.Action<Reply>` matching existing `SetChannelState` / `Notification.Schedule` patterns. Runtime iOS 16.1+ gating; no-op on non-iOS, older iOS, and editor.
- `StartedLiveActivity` has two overloads: raw `byte[]` (from ActivityKit) and hex `string` (for persisted tokens). Both funnel into the same native entry point.

## Key decisions
- **Attribution surface:** Live Activity taps surface `teak_live_activity_id` via the existing session-attribution path on the native iOS SDK, which flows through to Unity on `OnPostLaunchSummary`. No new Unity event is needed; documented on the class. End-to-end verification belongs in teak-unity-cleanroom on a device.
- **Marshaling:** `byte[]` with `[MarshalAs(UnmanagedType.LPArray)]` + length. The C wrapper copies into `NSData` before returning, so the managed-array pin only needs to last for the synchronous call.
- **Reply shape:** Single `LiveActivity.Reply` class with an optional `CanceledCount`. The native `TeakOperationLiveActivityCancelResult` flattens into `{status, errors, canceled}` so one Reply type covers all three APIs.
- **Ctor visibility:** `Reply(Dictionary<string,object>)` is `public` (not `internal` like `Channel.Reply` / `Notification.Reply`) because `Assets/Tests/Editor/` compiles into `Assembly-CSharp-Editor`, a separate assembly from the runtime `Assembly-CSharp` — internal members aren't cross-assembly. The Teak CLAUDE.md note about internals-visibility is accurate only for editor-only runtime code (`Assets/Teak/Editor/`), not cross-assembly.

## Test plan
- [x] `bundle exec rake test` equivalent: `Unity -executeMethod TeakTestRunner.RunAll -quit -nographics -batchmode -projectPath .` → 23 passed, 0 failed (11 new Live Activity tests covering Reply parsing + hex-decode validation).
- [ ] Cleanroom: build an iOS app consuming the new wrappers, verify on device (16.1+) that `StartedLiveActivity` dispatches the token/activity-id, `ScheduleLiveActivityUpdate` schedules a server push, and a tap on the Live Activity surfaces `teak_live_activity_id` on `OnPostLaunchSummary`.
- [ ] Cleanroom: verify no-op behavior below iOS 16.1 and on Android (callback should invoke with a non-error Reply without attempting P/Invoke).