### PR TITLE
feat(C-703): Unity SDK — TeakSettings claim mode + build writers + enum

### DIFF
--- a/Assets/Teak/Editor/TeakAndroidAssetLibBuilder.cs
+++ b/Assets/Teak/Editor/TeakAndroidAssetLibBuilder.cs
@@ -34,7 +34,7 @@ public class TeakAndroidAssetLibBuilder : IPreprocessBuildWithReport {
 
         // res/values/teak.xml
         bool forceDebugOutput = TeakSettings.ForceDebugOutput || isDevelopmentBuild;
-        XDocument doc = BuildTeakResourcesXml(TeakSettings.AppId, TeakSettings.APIKey, forceDebugOutput);
+        XDocument doc = BuildTeakResourcesXml(TeakSettings.AppId, TeakSettings.APIKey, forceDebugOutput, TeakSettings.ClaimModeNativeString);
         doc.Save(Path.Combine(Application.dataPath, androidLibPath, "res/values/teak.xml"));
 
         // project.properties
@@ -57,10 +57,11 @@ public class TeakAndroidAssetLibBuilder : IPreprocessBuildWithReport {
         AssetDatabase.SaveAssets();
     }
 
-    internal static XDocument BuildTeakResourcesXml(string appId, string apiKey, bool forceDebugOutput) {
+    internal static XDocument BuildTeakResourcesXml(string appId, string apiKey, bool forceDebugOutput, string claimMode) {
         XElement resources = new XElement("resources",
             new XElement("string", appId, new XAttribute("name", "io_teak_app_id")),
-            new XElement("string", apiKey, new XAttribute("name", "io_teak_api_key"))
+            new XElement("string", apiKey, new XAttribute("name", "io_teak_api_key")),
+            new XElement("string", claimMode, new XAttribute("name", "io_teak_reward_claim_mode"))
         );
 
         if (forceDebugOutput) {

--- a/Assets/Teak/Editor/TeakSettingsEditor.cs
+++ b/Assets/Teak/Editor/TeakSettingsEditor.cs
@@ -32,6 +32,9 @@ public class TeakSettingsEditor : Editor {
         TeakSettings.ShortlinkDomain = EditorGUILayout.TextField("ShortLink Domain", TeakSettings.ShortlinkDomain);
         TeakSettings.TraceLogging = EditorGUILayout.Toggle("Trace Logging", TeakSettings.TraceLogging);
 
+        GUIContent claimModeContent = new GUIContent("Reward Claim Mode [?]", "Selects how the SDK declares reward claims to the Teak server. 'Legacy' is the existing server-reconciliation behavior. 'ClientJwt' and 'ServerJwt' enable JWT-signed claims. Must be one of the values declared in supported_claim_modes for your game.");
+        TeakSettings.ClaimMode = (TeakClaimMode) EditorGUILayout.EnumPopup(claimModeContent, TeakSettings.ClaimMode);
+
         EditorGUILayout.Space();
         GUILayout.Label("Build Settings", EditorStyles.boldLabel);
         GUIContent justShutUpIKnowWhatImDoingContent = new GUIContent("Build Post-Processing [?]",  "When enabled, Teak will post-proces the Unity build and add dependencies, generate plist, XML, etc.");

--- a/Assets/Teak/Editor/TeakXcodeProjectMutator.cs
+++ b/Assets/Teak/Editor/TeakXcodeProjectMutator.cs
@@ -95,6 +95,9 @@ public class TeakXcodeProjectMutator : IPostprocessBuildWithReport {
         // Force debug output
         plist.root.SetBoolean("TeakForceDebugOutput", TeakSettings.ForceDebugOutput || isDevelopmentBuild);
 
+        // Reward claim mode
+        plist.root.SetString("TeakRewardClaimMode", TeakSettings.ClaimModeNativeString);
+
         return plist.WriteToString();
     }
 

--- a/Assets/Teak/TeakReward.cs
+++ b/Assets/Teak/TeakReward.cs
@@ -36,6 +36,15 @@ public class TeakReward {
         /// <summary>Teak does not recognize this reward id.</summary>
         InvalidPost,
 
+        /// <summary>The player is not eligible for this reward (e.g. targeting rules excluded them).</summary>
+        PlayerIneligible,
+
+        /// <summary>No reward is currently available for this campaign.</summary>
+        NoRewardAvailable,
+
+        /// <summary>The configured ``claim_mode`` is not in the game's ``supported_claim_modes``.</summary>
+        ClaimModeUnsupported,
+
         /// <summary>Another error occurred that prevented the Reward from being processed.</summary>
         InternalError
     }
@@ -152,6 +161,24 @@ public class TeakReward {
             case "invalid_post": {
                 // Teak does not recognize this reward id
                 this.Status = RewardStatus.InvalidPost;
+            }
+            break;
+
+            case "player_ineligible": {
+                // The player is not eligible for this reward
+                this.Status = RewardStatus.PlayerIneligible;
+            }
+            break;
+
+            case "no_reward_available": {
+                // No reward is currently available for this campaign
+                this.Status = RewardStatus.NoRewardAvailable;
+            }
+            break;
+
+            case "claim_mode_unsupported": {
+                // The configured claim_mode is not in the game's supported_claim_modes
+                this.Status = RewardStatus.ClaimModeUnsupported;
             }
             break;
         }

--- a/Assets/Teak/TeakSettings.cs
+++ b/Assets/Teak/TeakSettings.cs
@@ -9,6 +9,16 @@ using UnityEditor;
 #endif
 #endregion
 
+/// <summary>The reward claim mode the SDK declares to the Teak server on every click.</summary>
+public enum TeakClaimMode {
+    /// <summary>Server reconciles clicks against rewards (current behavior, default).</summary>
+    Legacy,
+    /// <summary>Client claims rewards using a JWT signed by Teak.</summary>
+    ClientJwt,
+    /// <summary>Server-to-server claim using a JWT signed by Teak.</summary>
+    ServerJwt
+}
+
 #if UNITY_EDITOR
 [InitializeOnLoad]
 #endif
@@ -126,6 +136,32 @@ public class TeakSettings : ScriptableObject {
 #endif
     }
 
+    public static TeakClaimMode ClaimMode {
+        get { return Instance.mClaimMode; }
+#if UNITY_EDITOR
+        set {
+            if (value != Instance.mClaimMode) {
+                Instance.mClaimMode = value;
+                DirtyEditor();
+            }
+        }
+#endif
+    }
+
+    /// <summary>The native-SDK string for the configured claim mode (e.g. ``legacy``, ``client_jwt``, ``server_jwt``).</summary>
+    public static string ClaimModeNativeString {
+        get { return ClaimModeToNativeString(Instance.mClaimMode); }
+    }
+
+    public static string ClaimModeToNativeString(TeakClaimMode mode) {
+        switch (mode) {
+            case TeakClaimMode.ClientJwt: return "client_jwt";
+            case TeakClaimMode.ServerJwt: return "server_jwt";
+            case TeakClaimMode.Legacy:
+            default: return "legacy";
+        }
+    }
+
     public static int iOSBuildPostProcessorCallbackOrder {
         get { return Instance.miOSBuildPostProcessorCallbackOrder; }
 #if UNITY_EDITOR
@@ -165,6 +201,8 @@ public class TeakSettings : ScriptableObject {
     private bool mForceDebugOutput = false;
     [SerializeField]
     private int miOSBuildPostProcessorCallbackOrder = 100;
+    [SerializeField]
+    private TeakClaimMode mClaimMode = TeakClaimMode.Legacy;
 
     private static TeakSettings mInstance;
 }

--- a/Assets/Tests/Editor/TeakAndroidAssetLibBuilderTests.cs
+++ b/Assets/Tests/Editor/TeakAndroidAssetLibBuilderTests.cs
@@ -5,7 +5,7 @@ public class TeakAndroidAssetLibBuilderTests {
 
     [TeakTest]
     public void ForceDebugOutputTrue_IncludesBoolElement() {
-        XDocument doc = TeakAndroidAssetLibBuilder.BuildTeakResourcesXml("app-id", "api-key", true);
+        XDocument doc = TeakAndroidAssetLibBuilder.BuildTeakResourcesXml("app-id", "api-key", true, "legacy");
         string xml = doc.ToString();
         TeakAssert.IsTrue(xml.Contains("<bool name=\"io_teak_force_debug_output\">true</bool>"),
             "Expected XML to contain io_teak_force_debug_output bool element set to true");
@@ -13,7 +13,7 @@ public class TeakAndroidAssetLibBuilderTests {
 
     [TeakTest]
     public void ForceDebugOutputFalse_OmitsBoolElement() {
-        XDocument doc = TeakAndroidAssetLibBuilder.BuildTeakResourcesXml("app-id", "api-key", false);
+        XDocument doc = TeakAndroidAssetLibBuilder.BuildTeakResourcesXml("app-id", "api-key", false, "legacy");
         string xml = doc.ToString();
         TeakAssert.IsFalse(xml.Contains("io_teak_force_debug_output"),
             "Expected XML to NOT contain io_teak_force_debug_output when false");
@@ -21,9 +21,33 @@ public class TeakAndroidAssetLibBuilderTests {
 
     [TeakTest]
     public void AppIdAndApiKeyPresent() {
-        XDocument doc = TeakAndroidAssetLibBuilder.BuildTeakResourcesXml("my-app", "my-key", false);
+        XDocument doc = TeakAndroidAssetLibBuilder.BuildTeakResourcesXml("my-app", "my-key", false, "legacy");
         string xml = doc.ToString();
         TeakAssert.IsTrue(xml.Contains("my-app"), "Expected XML to contain app id");
         TeakAssert.IsTrue(xml.Contains("my-key"), "Expected XML to contain api key");
+    }
+
+    [TeakTest]
+    public void ClaimModeLegacy_WritesLegacyString() {
+        XDocument doc = TeakAndroidAssetLibBuilder.BuildTeakResourcesXml("app-id", "api-key", false, "legacy");
+        string xml = doc.ToString();
+        TeakAssert.IsTrue(xml.Contains("<string name=\"io_teak_reward_claim_mode\">legacy</string>"),
+            "Expected XML to contain io_teak_reward_claim_mode=legacy");
+    }
+
+    [TeakTest]
+    public void ClaimModeClientJwt_WritesClientJwtString() {
+        XDocument doc = TeakAndroidAssetLibBuilder.BuildTeakResourcesXml("app-id", "api-key", false, "client_jwt");
+        string xml = doc.ToString();
+        TeakAssert.IsTrue(xml.Contains("<string name=\"io_teak_reward_claim_mode\">client_jwt</string>"),
+            "Expected XML to contain io_teak_reward_claim_mode=client_jwt");
+    }
+
+    [TeakTest]
+    public void ClaimModeServerJwt_WritesServerJwtString() {
+        XDocument doc = TeakAndroidAssetLibBuilder.BuildTeakResourcesXml("app-id", "api-key", false, "server_jwt");
+        string xml = doc.ToString();
+        TeakAssert.IsTrue(xml.Contains("<string name=\"io_teak_reward_claim_mode\">server_jwt</string>"),
+            "Expected XML to contain io_teak_reward_claim_mode=server_jwt");
     }
 }

--- a/Assets/Tests/Editor/TeakClaimModeTests.cs
+++ b/Assets/Tests/Editor/TeakClaimModeTests.cs
@@ -1,0 +1,18 @@
+[TeakTestFixture]
+public class TeakClaimModeTests {
+
+    [TeakTest]
+    public void Legacy_MapsToLegacyString() {
+        TeakAssert.AreEqual("legacy", TeakSettings.ClaimModeToNativeString(TeakClaimMode.Legacy));
+    }
+
+    [TeakTest]
+    public void ClientJwt_MapsToClientJwtString() {
+        TeakAssert.AreEqual("client_jwt", TeakSettings.ClaimModeToNativeString(TeakClaimMode.ClientJwt));
+    }
+
+    [TeakTest]
+    public void ServerJwt_MapsToServerJwtString() {
+        TeakAssert.AreEqual("server_jwt", TeakSettings.ClaimModeToNativeString(TeakClaimMode.ServerJwt));
+    }
+}

--- a/Assets/Tests/Editor/TeakClaimModeTests.cs.meta
+++ b/Assets/Tests/Editor/TeakClaimModeTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3c33699a93ca462d8cd6c07d6d65ab75

--- a/Assets/Tests/Editor/TeakRewardStatusMappingTests.cs
+++ b/Assets/Tests/Editor/TeakRewardStatusMappingTests.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+
+[TeakTestFixture]
+public class TeakRewardStatusMappingTests {
+
+    private static TeakReward MakeReward(string status) {
+        var json = new Dictionary<string, object> {
+            { "teakRewardId", "reward-id" },
+            { "status", status }
+        };
+        return new TeakReward(json);
+    }
+
+    [TeakTest]
+    public void PlayerIneligible_MapsToPlayerIneligible() {
+        TeakReward reward = MakeReward("player_ineligible");
+        TeakAssert.AreEqual(TeakReward.RewardStatus.PlayerIneligible, reward.Status);
+    }
+
+    [TeakTest]
+    public void NoRewardAvailable_MapsToNoRewardAvailable() {
+        TeakReward reward = MakeReward("no_reward_available");
+        TeakAssert.AreEqual(TeakReward.RewardStatus.NoRewardAvailable, reward.Status);
+    }
+
+    [TeakTest]
+    public void ClaimModeUnsupported_MapsToClaimModeUnsupported() {
+        TeakReward reward = MakeReward("claim_mode_unsupported");
+        TeakAssert.AreEqual(TeakReward.RewardStatus.ClaimModeUnsupported, reward.Status);
+    }
+
+    [TeakTest]
+    public void GrantReward_StillMapsCorrectly() {
+        var json = new Dictionary<string, object> {
+            { "teakRewardId", "reward-id" },
+            { "status", "grant_reward" },
+            { "reward", new Dictionary<string, object> { { "coins", 100 } } }
+        };
+        TeakReward reward = new TeakReward(json);
+        TeakAssert.AreEqual(TeakReward.RewardStatus.GrantReward, reward.Status);
+    }
+
+    [TeakTest]
+    public void UnknownStatus_StaysInternalError() {
+        TeakReward reward = MakeReward("some_unknown_value");
+        TeakAssert.AreEqual(TeakReward.RewardStatus.InternalError, reward.Status);
+    }
+}

--- a/Assets/Tests/Editor/TeakRewardStatusMappingTests.cs.meta
+++ b/Assets/Tests/Editor/TeakRewardStatusMappingTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0b6c89cba5f14225bf791780207ce89c

--- a/docs/modules/changelog/unreleased.yaml
+++ b/docs/modules/changelog/unreleased.yaml
@@ -1,1 +1,3 @@
-
+new:
+  - "Added a Reward Claim Mode dropdown to TeakSettings (``Legacy``, ``ClientJwt``, ``ServerJwt``). Build post-processors write the configured value to ``TeakRewardClaimMode`` in iOS Info.plist and to the ``io_teak_reward_claim_mode`` Android string resource. Defaults to ``Legacy``."
+  - "Added ``TeakReward.RewardStatus`` values ``PlayerIneligible``, ``NoRewardAvailable``, and ``ClaimModeUnsupported`` to mirror the new native reward statuses."


### PR DESCRIPTION
Closes https://linear.app/teakio/issue/C-703/unity-sdk-teaksettings-claim-mode-build-writers-enum

## Summary

Adds a Reward Claim Mode dropdown to the Unity Inspector and build-time
writers that materialize the selection into both platform-config files
the native SDKs read at startup. iOS post-build writes
`TeakRewardClaimMode` into `Info.plist`; Android pre-build writes the
`io_teak_reward_claim_mode` string into `res/values/teak.xml` alongside
`io_teak_app_id` and `io_teak_api_key`. Also extends the C#
`TeakReward.RewardStatus` enum with `PlayerIneligible`,
`NoRewardAvailable`, and `ClaimModeUnsupported` to mirror the new
native enum values, and maps the matching JSON status strings into
them. Unity inherits click payload + reconciliation from the native
SDKs — that's not in this PR.

## Key decisions

- **Spec naming was stale; PR uses the post-rename keys.** The C-703
  Linear spec said write `TeakClaimMode` to iOS Info.plist and
  `io_teak_claim_mode` to the Android strings XML. Both keys were
  renamed during the C-697 (iOS) and C-700 (Android) reviews after the
  spec was written. The merged iOS SDK on `feat/simplify-rewards`
  reads `TeakRewardClaimMode`
  (`Teak/Configuration/TeakAppConfiguration.m:74`); the merged Android
  SDK reads `io_teak_reward_claim_mode`
  (`src/main/java/io/teak/sdk/configuration/AppConfiguration.java:66`).
  The Unity writers match the native read keys, not the spec.
- **Native-string helper is `public`, not `internal`.** `TeakSettings`
  lives in the runtime assembly (`Assembly-CSharp`); tests live in the
  editor assembly (`Assembly-CSharp-Editor`). Without an `.asmdef`
  granting `InternalsVisibleTo`, the native-string helper has to be
  `public` for unit tests to call it.
- **`BuildTeakResourcesXml` takes claim mode as a parameter rather
  than reading `TeakSettings` directly.** Matches the existing pattern
  for `appId` / `apiKey` / `forceDebugOutput` — keeps the helper pure
  and testable, with the call site passing
  `TeakSettings.ClaimModeNativeString`.

## Test plan

- [x] `Unity 2022.3.21f1 -executeMethod TeakTestRunner.RunAll` —
      33 / 33 tests pass, including six new ones across the two new
      fixtures (claim-mode native-string mapping; reward status JSON
      mapping for each new value) plus three new
      `BuildTeakResourcesXml` cases asserting the strings XML contains
      `<string name="io_teak_reward_claim_mode">…</string>` for
      `legacy`, `client_jwt`, and `server_jwt`.
- [ ] CI green on draft PR (deferred to dispatcher).

## Readers left behind

None. Click payload + reconciliation in Unity inherits from the native
SDKs and is explicitly out of scope for this issue.