### PR TITLE
Fix WebGL callback ID collision when scheduling multiple notifications in a frame

### DIFF
--- a/Assets/Teak/Teak.Operation.cs
+++ b/Assets/Teak/Teak.Operation.cs
@@ -98,7 +98,7 @@ public partial class Teak {
         }
 #elif UNITY_WEBGL
         public Operation(Action<string> init) {
-            string callbackId = (++_nextCallbackId).ToString();
+            string callbackId = NextCallbackID();
             teakOperationCallbackMap.Add(callbackId, json => {
                 this.result = json;
                 this.markDoneOnNextCheck = true;
@@ -129,7 +129,8 @@ public partial class Teak {
     }
 
     /// @cond hide_from_doxygen
-    internal static long _nextCallbackId = 0L;
+    private static long _nextCallbackId = 0L;
+    internal static string NextCallbackID() => (++_nextCallbackId).ToString();
     internal static Dictionary<string, System.Action<Dictionary<string, object>>> teakOperationCallbackMap = new Dictionary<string, System.Action<Dictionary<string, object>>>();
     void TeakOperationCallback(string jsonString) {
         try {

--- a/Assets/Teak/Teak.Operation.cs
+++ b/Assets/Teak/Teak.Operation.cs
@@ -98,7 +98,7 @@ public partial class Teak {
         }
 #elif UNITY_WEBGL
         public Operation(Action<string> init) {
-            string callbackId = DateTime.Now.Ticks.ToString();
+            string callbackId = (++_nextCallbackId).ToString();
             teakOperationCallbackMap.Add(callbackId, json => {
                 this.result = json;
                 this.markDoneOnNextCheck = true;
@@ -129,6 +129,7 @@ public partial class Teak {
     }
 
     /// @cond hide_from_doxygen
+    internal static long _nextCallbackId = 0L;
     internal static Dictionary<string, System.Action<Dictionary<string, object>>> teakOperationCallbackMap = new Dictionary<string, System.Action<Dictionary<string, object>>>();
     void TeakOperationCallback(string jsonString) {
         try {

--- a/Assets/Teak/Teak.cs
+++ b/Assets/Teak/Teak.cs
@@ -716,7 +716,7 @@ public partial class Teak : MonoBehaviour {
         yield return null;
 #elif UNITY_IPHONE
         bool keepWaiting = true;
-        string callbackId = (++_nextCallbackId).ToString();
+        string callbackId = NextCallbackID();
         teakOperationCallbackMap.Add(callbackId, json => {
             if (callback != null) {
                 callback(json.ContainsKey("permissionGranted") && json["permissionGranted"] is bool && (bool)json["permissionGranted"]);
@@ -756,7 +756,7 @@ public partial class Teak : MonoBehaviour {
         yield return null;
 #elif UNITY_IPHONE
         bool keepWaiting = true;
-        string callbackId = (++_nextCallbackId).ToString();
+        string callbackId = NextCallbackID();
         teakOperationCallbackMap.Add(callbackId, json => {
             if (callback != null) {
                 callback(json.ContainsKey("permissionGranted") && json["permissionGranted"] is bool && (bool)json["permissionGranted"]);

--- a/Assets/Teak/Teak.cs
+++ b/Assets/Teak/Teak.cs
@@ -716,7 +716,7 @@ public partial class Teak : MonoBehaviour {
         yield return null;
 #elif UNITY_IPHONE
         bool keepWaiting = true;
-        string callbackId = DateTime.Now.Ticks.ToString();
+        string callbackId = (++_nextCallbackId).ToString();
         teakOperationCallbackMap.Add(callbackId, json => {
             if (callback != null) {
                 callback(json.ContainsKey("permissionGranted") && json["permissionGranted"] is bool && (bool)json["permissionGranted"]);
@@ -756,7 +756,7 @@ public partial class Teak : MonoBehaviour {
         yield return null;
 #elif UNITY_IPHONE
         bool keepWaiting = true;
-        string callbackId = DateTime.Now.Ticks.ToString();
+        string callbackId = (++_nextCallbackId).ToString();
         teakOperationCallbackMap.Add(callbackId, json => {
             if (callback != null) {
                 callback(json.ContainsKey("permissionGranted") && json["permissionGranted"] is bool && (bool)json["permissionGranted"]);

--- a/Assets/Teak/TeakNotification.cs
+++ b/Assets/Teak/TeakNotification.cs
@@ -206,7 +206,7 @@ public partial class TeakNotification {
 
         SafePerformCallback("schedule_notification.local", callback, data, status, scheduleName);
 #elif UNITY_WEBGL
-        string callbackId = DateTime.Now.Ticks.ToString();
+        string callbackId = (++Teak._nextCallbackId).ToString();
         webGlCallbackMap.Add(callbackId, callback);
         TeakNotificationSchedule(callbackId, scheduleName, defaultMessage, delayInSeconds);
         yield return null;
@@ -269,7 +269,7 @@ public partial class TeakNotification {
 
         SafePerformCallback("schedule_notification.long_distance", callback, data, status, scheduleName);
 #elif UNITY_WEBGL
-        string callbackId = DateTime.Now.Ticks.ToString();
+        string callbackId = (++Teak._nextCallbackId).ToString();
         webGlCallbackMap.Add(callbackId, callback);
         TeakNotificationScheduleLongDistance(callbackId, scheduleName, Json.Serialize(userIds), delayInSeconds);
         yield return null;
@@ -324,7 +324,7 @@ public partial class TeakNotification {
 
         SafePerformCallback("cancel_notification", callback, data, status, null);
 #elif UNITY_WEBGL
-        string callbackId = DateTime.Now.Ticks.ToString();
+        string callbackId = (++Teak._nextCallbackId).ToString();
         webGlCallbackMap.Add(callbackId, callback);
         TeakNotificationCancel(callbackId, scheduleId);
         yield return null;
@@ -378,7 +378,7 @@ public partial class TeakNotification {
 
         SafePerformCallback("cancel_all_notifications", callback, data, status, null);
 #elif UNITY_WEBGL
-        string callbackId = DateTime.Now.Ticks.ToString();
+        string callbackId = (++Teak._nextCallbackId).ToString();
         webGlCallbackMap.Add(callbackId, callback);
         TeakNotificationCancelAll(callbackId);
         yield return null;

--- a/Assets/Teak/TeakNotification.cs
+++ b/Assets/Teak/TeakNotification.cs
@@ -206,7 +206,7 @@ public partial class TeakNotification {
 
         SafePerformCallback("schedule_notification.local", callback, data, status, scheduleName);
 #elif UNITY_WEBGL
-        string callbackId = (++Teak._nextCallbackId).ToString();
+        string callbackId = Teak.NextCallbackID();
         webGlCallbackMap.Add(callbackId, callback);
         TeakNotificationSchedule(callbackId, scheduleName, defaultMessage, delayInSeconds);
         yield return null;
@@ -269,7 +269,7 @@ public partial class TeakNotification {
 
         SafePerformCallback("schedule_notification.long_distance", callback, data, status, scheduleName);
 #elif UNITY_WEBGL
-        string callbackId = (++Teak._nextCallbackId).ToString();
+        string callbackId = Teak.NextCallbackID();
         webGlCallbackMap.Add(callbackId, callback);
         TeakNotificationScheduleLongDistance(callbackId, scheduleName, Json.Serialize(userIds), delayInSeconds);
         yield return null;
@@ -324,7 +324,7 @@ public partial class TeakNotification {
 
         SafePerformCallback("cancel_notification", callback, data, status, null);
 #elif UNITY_WEBGL
-        string callbackId = (++Teak._nextCallbackId).ToString();
+        string callbackId = Teak.NextCallbackID();
         webGlCallbackMap.Add(callbackId, callback);
         TeakNotificationCancel(callbackId, scheduleId);
         yield return null;
@@ -378,7 +378,7 @@ public partial class TeakNotification {
 
         SafePerformCallback("cancel_all_notifications", callback, data, status, null);
 #elif UNITY_WEBGL
-        string callbackId = (++Teak._nextCallbackId).ToString();
+        string callbackId = Teak.NextCallbackID();
         webGlCallbackMap.Add(callbackId, callback);
         TeakNotificationCancelAll(callbackId);
         yield return null;

--- a/docs/modules/changelog/unreleased.yaml
+++ b/docs/modules/changelog/unreleased.yaml
@@ -1,1 +1,2 @@
-
+bug:
+  - "Fix crash when scheduling multiple WebGL notifications in the same frame (callback IDs now use a monotonic counter instead of `DateTime.Now.Ticks`)."


### PR DESCRIPTION
Replace `DateTime.Now.Ticks.ToString()` with a shared monotonic counter (`Teak._nextCallbackId`) at all 7 callback-ID generation sites across `Teak.Operation.cs`, `Teak.cs`, and `TeakNotification.cs`.

Ticks-based IDs collide when multiple operations are created in the same Unity frame, causing `Dictionary.Add` to throw. A monotonic counter is guaranteed unique within the process lifetime with no entropy dependency (relevant because `Guid.NewGuid()` has known entropy issues under Unity WebGL IL2CPP).

Linear: https://linear.app/teakio/issue/C-833

🤖 Generated with [Claude Code](https://claude.com/claude-code)