### PR TITLE
Add RegisterPushToStartToken to Unity Live Activity API

### DIFF
--- a/Assets/Teak/Teak.LiveActivity.cs
+++ b/Assets/Teak/Teak.LiveActivity.cs
@@ -225,6 +225,48 @@ public partial class Teak {
         }
 
         /// <summary>
+        /// Report a Live Activity push-to-start token to Teak.
+        /// </summary>
+        /// <remarks>
+        /// Call this from any location where your app observes
+        /// <c>Activity&lt;Attributes&gt;.pushToStartTokenUpdates</c> — typically at launch and
+        /// again whenever the OS emits a rotated token.
+        ///
+        /// </remarks>
+        /// <param name="pushToken">The push-to-start token bytes from ActivityKit's <c>Activity.pushToStartTokenUpdates</c>.</param>
+        public static void RegisterPushToStartToken(byte[] pushToken) {
+            int tokenLength = pushToken == null ? 0 : pushToken.Length;
+
+            if (Teak.Instance.Trace) {
+                Debug.Log("[Teak.LiveActivity] RegisterPushToStartToken(<" + tokenLength + " bytes>)");
+            }
+
+#if !UNITY_EDITOR && UNITY_IPHONE
+            TeakRegisterPushToStartToken(pushToken, tokenLength);
+#endif
+        }
+
+        /// <summary>
+        /// Report a Live Activity push-to-start token to Teak, using a hex-encoded token string.
+        /// </summary>
+        /// <remarks>
+        /// Convenience overload for callers who already hold the token as a hex string
+        /// (for example, persisted via <c>PlayerPrefs</c>). Decodes to bytes and delegates to
+        /// <see cref="RegisterPushToStartToken(byte[])"/>.
+        /// </remarks>
+        /// <param name="pushTokenHex">The push-to-start token as a hex-encoded string.</param>
+        public static void RegisterPushToStartToken(string pushTokenHex) {
+            byte[] tokenBytes = null;
+            try {
+                tokenBytes = HexStringToBytes(pushTokenHex);
+            } catch (Exception e) {
+                Debug.LogError("[Teak.LiveActivity] RegisterPushToStartToken: failed to parse hex token: " + e.Message);
+                return;
+            }
+            RegisterPushToStartToken(tokenBytes);
+        }
+
+        /// <summary>
         /// Cancel all pending scheduled updates for a live activity.
         /// </summary>
         /// <remarks>
@@ -321,6 +363,11 @@ public partial class Teak {
 
         [DllImport ("__Internal")]
         private static extern IntPtr TeakCancelLiveActivityUpdates_Retained(string activityId);
+
+        [DllImport ("__Internal")]
+        private static extern void TeakRegisterPushToStartToken(
+            [MarshalAs(UnmanagedType.LPArray)] byte[] pushToken,
+            int pushTokenLength);
 #endif
         /// @endcond
     }

--- a/Assets/Tests/Editor/TeakLiveActivityTests.cs
+++ b/Assets/Tests/Editor/TeakLiveActivityTests.cs
@@ -77,6 +77,26 @@ public class TeakLiveActivityTests {
     }
 
     [TeakTest]
+    public void RegisterPushToStartTokenHexOverloadDoesNotThrowOnInvalidHex() {
+        var teak = new UnityEngine.GameObject("TeakForTest").AddComponent<Teak>();
+        try {
+            Teak.LiveActivity.RegisterPushToStartToken("zz");
+        } finally {
+            UnityEngine.Object.DestroyImmediate(teak.gameObject);
+        }
+    }
+
+    [TeakTest]
+    public void RegisterPushToStartTokenHexOverloadDoesNotThrowOnNull() {
+        var teak = new UnityEngine.GameObject("TeakForTest").AddComponent<Teak>();
+        try {
+            Teak.LiveActivity.RegisterPushToStartToken((string)null);
+        } finally {
+            UnityEngine.Object.DestroyImmediate(teak.gameObject);
+        }
+    }
+
+    [TeakTest]
     public void StartedLiveActivityHexOverloadInvokesErrorCallbackOnInvalidHex() {
         Teak.LiveActivity.Reply captured = null;
         var teak = new UnityEngine.GameObject("TeakForTest").AddComponent<Teak>();

--- a/docs/modules/changelog/unreleased.yaml
+++ b/docs/modules/changelog/unreleased.yaml
@@ -1,2 +1,4 @@
+new:
+  - "Add ``Teak.LiveActivity.RegisterPushToStartToken`` to report a Live Activity push-to-start token to Teak."
 bug:
   - "Fix crash when scheduling multiple WebGL notifications in the same frame (callback IDs now use a monotonic counter instead of `DateTime.Now.Ticks`)."


### PR DESCRIPTION
Exposes `Teak.LiveActivity.RegisterPushToStartToken` to Unity game code, wrapping the iOS 17.2+ push-to-start token registration that landed in teak-ios PR #142.

Two overloads matching the `StartedLiveActivity` surface:
- `byte[]` — primary, for tokens directly from ActivityKit's `Activity.pushToStartTokenUpdates`
- `string` (hex) — convenience overload for callers persisting the token via PlayerPrefs

On non-iOS/editor both are no-ops. `native.config.yml` pin stays at 4.3.12 — version bump deferred to ship time when teak-ios 4.3.13 is tagged.

24/0 Unity editor tests pass (BUILD_LOCAL=true against teak-ios with #142 merged).

https://linear.app/teakio/issue/C-746